### PR TITLE
fix: add contents:read permission for checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read   # checkout private repo
       id-token: write  # trusted publishing
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
+      contents: read   # checkout private repo
       id-token: write  # trusted publishing
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2


### PR DESCRIPTION
Private repo needs explicit contents:read for checkout action.