### PR TITLE
fix: lazy import cryptography — broken install without extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-sdk"
-version = "0.0.1a1"
+version = "0.0.1a2"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/chat_sdk/adapters/slack/crypto.py
+++ b/src/chat_sdk/adapters/slack/crypto.py
@@ -10,8 +10,6 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-
 ALGORITHM = "aes-256-gcm"
 IV_LENGTH = 12
 AUTH_TAG_LENGTH = 16
@@ -39,6 +37,8 @@ def encrypt_token(plaintext: str, key: bytes) -> EncryptedTokenData:
     """
     import base64
 
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
     iv = os.urandom(IV_LENGTH)
     aesgcm = AESGCM(key)
     # AESGCM.encrypt returns ciphertext + tag concatenated
@@ -65,6 +65,8 @@ def decrypt_token(encrypted: EncryptedTokenData, key: bytes) -> str:
         The decrypted plaintext token.
     """
     import base64
+
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
     iv = base64.b64decode(encrypted.iv)
     ciphertext = base64.b64decode(encrypted.data)


### PR DESCRIPTION
Installing `chat-sdk` without `[crypto]` extra crashed on import because `adapters/__init__.py` eagerly imports all adapters, which imports `slack/crypto.py`, which imports `cryptography` at module level. Fixed by making the import lazy inside the encrypt/decrypt functions. Also bumps to `0.0.1a2` for TestPyPI re-publish.