### PR TITLE
chore: bump to 0.0.1a3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-sdk"
-version = "0.0.1a2"
+version = "0.0.1a3"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Clean release with zero lint warnings.