### PR TITLE
sync: upstream Vercel Chat v4.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.25.0 (2026-04-10)
+
+Synced to [Vercel Chat 4.25.0](https://github.com/vercel/chat). New versioning: our minor version matches the upstream minor version.
+
+### New features (from upstream 4.25.0)
+- **Plan blocks**: `Plan` PostableObject for structured task lists with live updates. Post a plan to a thread, then `add_task()`, `update_task()`, and `complete()` with automatic card rendering.
+- **Streaming table option**: `StreamingMarkdownRenderer(wrap_tables_for_append=False)` disables code-fence wrapping for platforms with native table support. Slack adapter now uses this by default.
+- **Teams Select/RadioSelect**: `Select` and `RadioSelect` card elements now render as Adaptive Card `Input.ChoiceSet` with auto-injected submit button.
+- **GitHub issue threads**: `issue_comment` webhooks on plain issues (not just PRs) now create threads with format `github:owner/repo:issue:42`.
+- **Slack OAuth redirect fix**: `handle_oauth_callback` correctly forwards `redirect_uri` option.
+
+### Versioning
+- Version scheme changed from `0.0.1aX` to `0.{upstream_minor}.{patch}`
+- `UPSTREAM_PARITY` constant in `chat_sdk.__init__` for programmatic access
+- Sync procedure documented in [UPSTREAM_SYNC.md](docs/UPSTREAM_SYNC.md)
+
 ## 0.0.1a12 (2026-04-10)
 
 Python 3.10 support, async-safe Chat resolver, and a large correctness audit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,57 @@
 # Claude Code Quick Reference -- chat-sdk-python
 
 ## What is this?
-Python port of Vercel Chat SDK. Multi-platform async chat framework.
+Python port of [Vercel Chat SDK](https://github.com/vercel/chat) (v4.25.0). Multi-platform async chat framework.
 
 ## Key Commands
-- `uv sync --group dev` -- install dependencies
-- `uv run pytest tests/ -q` -- run tests
-- `uv run ruff check src/` -- lint
-- `uv run ruff format src/` -- format
+```bash
+uv sync --group dev           # install dependencies
+uv run pytest tests/ -q       # run tests
+uv run ruff check src/ tests/ scripts/  # lint
+uv run ruff format src/ tests/ scripts/ # format
+
+# Full validation — run before declaring any task done
+uv run ruff check src/ tests/ scripts/ && \
+uv run ruff format --check src/ tests/ scripts/ && \
+uv run python scripts/audit_test_quality.py && \
+uv run python scripts/verify_test_fidelity.py && \
+uv run pytest tests/ --tb=short -q
+```
+
+## Version Mapping
+Our version tracks the upstream Vercel Chat minor version:
+- `0.25.0` = synced to upstream `4.25.0`
+- `0.25.1` = Python-only fixes on top of `4.25.0`
+- `0.26.0` = synced to upstream `4.26.0`
+- `UPSTREAM_PARITY` constant in `__init__.py` = programmatic access
 
 ## Architecture
-- `src/chat_sdk/chat.py` -- Main Chat orchestrator (handlers, routing, concurrency)
+- `src/chat_sdk/chat.py` -- Chat orchestrator (handlers, routing, concurrency)
 - `src/chat_sdk/thread.py` -- Thread (streaming, pagination, subscriptions)
 - `src/chat_sdk/channel.py` -- Channel (thread listing, metadata)
+- `src/chat_sdk/plan.py` -- Plan (PostableObject for structured task lists)
 - `src/chat_sdk/types.py` -- All types (Message, Author, Adapter protocol)
 - `src/chat_sdk/adapters/` -- 8 platform adapters
 - `src/chat_sdk/shared/` -- Markdown parser, format converter, streaming renderer
 - `src/chat_sdk/state/` -- Memory, Redis, Postgres backends
-- `tests/` -- 3,267 tests
+- `tests/` -- 3,400+ tests
+
+### Thread ID Format
+All thread IDs follow: `{adapter}:{channel}:{thread}`
+- Slack: `slack:C123ABC:1234567890.123456`
+- Teams: `teams:{base64(conversationId)}:{base64(serviceUrl)}`
+- Google Chat: `gchat:spaces/ABC123:{base64(threadName)}`
+- Discord: `discord:{guildId}:{channelId}[:{threadId}]`
+- GitHub: `github:owner/repo:42` (PR) or `github:owner/repo:issue:42`
+
+### Message Handling Flow
+1. Platform sends webhook → adapter verifies + parses
+2. Adapter calls `chat.process_message()` (or `process_action`, etc.)
+3. Chat acquires lock, deduplicates, then routes:
+   - Subscribed thread → `on_subscribed_message` handlers
+   - @mention → `on_mention` handlers
+   - DM → `on_direct_message` handlers
+   - Pattern match → `on_message` handlers
 
 ## Principles
 
@@ -31,25 +65,22 @@ Python port of Vercel Chat SDK. Multi-platform async chat framework.
 
 ## Port Rules (TS → Python)
 
-These are specific patterns that broke during the port. The principles above
-explain *why*; these explain *what to watch for*.
+See docs/UPSTREAM_SYNC.md for the full 15-hazard guide. Key patterns:
 
-- `datetime.utcnow()` → `datetime.now(tz=UTC)` (deprecated, naive)
-- `asyncio.ensure_future` → `loop.create_task()` (deprecated)
+- `x or default` → `x if x is not None else default` (truthiness trap)
+- `datetime.utcnow()` → `datetime.now(tz=timezone.utc)` (deprecated, naive)
 - Raw dicts to `process_*` → typed dataclasses (ActionEvent, etc.)
-- camelCase dispatch keys → snake_case
+- camelCase dispatch keys → snake_case internally, camelCase at serialization boundary
 - `random.choices` for tokens → `secrets.token_hex`
-- Optional deps at module level → lazy import
+- Optional deps at module level → lazy import inside methods
 - `==` for signatures → `hmac.compare_digest`
-- `or` for empty-string-valid fields → `is not None`
 - Validate external URLs before requests (SSRF)
-- Check `extend_lock` return value in loops
-
-## Adding a New Adapter
-See docs/ARCHITECTURE.md and CONTRIBUTING.md.
+- `chat.activate()` > `register_singleton()` > error (3-level resolver)
 
 ## Upstream Sync
-See docs/UPSTREAM_SYNC.md for TS->Python translation patterns.
+
+See docs/UPSTREAM_SYNC.md for the full sync procedure, porting hazards, review
+checklist, and known non-parity list.
 
 ## Known Limitations
 - Markdown parser handles common cases but is not full CommonMark
@@ -63,5 +94,5 @@ async mock bugs, and cross-file duplicates. PRs that introduce hard failures
 will not pass CI.
 
 **Fidelity check** (`scripts/verify_test_fidelity.py`) verifies every TS
-`it("...")` has a matching Python `def test_*()`. Name match ≠ faithful port —
-the audit script catches the quality side.
+`it("...")` has a matching Python `def test_*()`. Must show 0 missing before
+committing test changes.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Multi-platform async chat SDK for Python. Port of [Vercel Chat](https://github.com/vercel/chat).
 
-> **Status: Alpha (0.0.1a12)** — API may change. Not yet tested in production.
+> **Status: Alpha (0.25.0 — synced to [Vercel Chat 4.25.0](https://github.com/vercel/chat))** — API may change.
 
 ## Why chat-sdk?
 

--- a/docs/UPSTREAM_SYNC.md
+++ b/docs/UPSTREAM_SYNC.md
@@ -2,6 +2,66 @@
 
 How to keep `chat-sdk-python` in sync with the [Vercel Chat TS SDK](https://github.com/vercel/chat).
 
+## Version Mapping
+
+Our version number tracks the upstream Vercel Chat minor version:
+
+| Python version | Upstream version | Meaning |
+|---|---|---|
+| `0.25.0` | `4.25.0` | Synced to upstream 4.25.0 |
+| `0.25.1` | `4.25.0` | Python-only fix on top of 4.25.0 |
+| `0.26.0` | `4.26.0` | Synced to upstream 4.26.0 |
+
+The `UPSTREAM_PARITY` constant in `chat_sdk/__init__.py` provides programmatic access
+to the upstream version this release is synced to.
+
+## How to Sync an Upstream Release
+
+Step-by-step procedure for porting a new upstream release (e.g., `4.26.0`):
+
+```bash
+# 1. Update the TS repo and check what changed
+cd /tmp/vercel-chat && git fetch origin
+git log --oneline chat@4.25.0..chat@4.26.0 -- packages/
+
+# 2. For each commit, read the diff
+git diff chat@4.25.0..chat@4.26.0 -- packages/chat/src/
+git diff chat@4.25.0..chat@4.26.0 -- packages/adapter-slack/src/
+# ... repeat for each changed package
+
+# 3. Create a sync branch
+cd /tmp/chat-sdk-python
+git checkout -b sync/upstream-v4.26.0
+
+# 4. Port each change following the TS → Python Porting Hazards below
+
+# 5. Run full validation
+uv run ruff check src/ tests/ scripts/
+uv run ruff format --check src/ tests/ scripts/
+uv run python scripts/audit_test_quality.py
+uv run python scripts/verify_test_fidelity.py
+uv run pytest tests/ --tb=short -q
+
+# 6. Update version
+#    - pyproject.toml: version = "0.26.0"
+#    - README.md: status line
+#    - __init__.py: UPSTREAM_PARITY = "4.26.0"
+#    - CLAUDE.md: version reference
+#    - CHANGELOG.md: new entry
+
+# 7. PR, merge, publish
+gh pr create --title "sync: upstream v4.26.0"
+```
+
+### What to check for each upstream commit
+
+- [ ] New types or fields → add to `types.py`
+- [ ] New methods on Thread/Channel → add to `thread.py`/`channel.py`
+- [ ] New adapter features → update the adapter + tests
+- [ ] New TS tests → run fidelity script, port missing tests
+- [ ] Changed behavior → verify Python matches with regression tests
+- [ ] Review the porting hazards below for each change
+
 ## How to Diff Upstream Changes
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-sdk"
-version = "0.0.1a12"
+version = "0.25.0"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/chat_sdk/__init__.py
+++ b/src/chat_sdk/__init__.py
@@ -86,6 +86,21 @@ from chat_sdk.modals import (
     select_option,
     text_input,
 )
+from chat_sdk.plan import (
+    AddTaskOptions,
+    CompletePlanOptions,
+    Plan,
+    PlanContent,
+    PlanModel,
+    PlanModelTask,
+    PlanTask,
+    PlanTaskStatus,
+    PostableObjectContext,
+    StartPlanOptions,
+    UpdateTaskInput,
+    is_postable_object,
+    post_postable_object,
+)
 from chat_sdk.shared.base_format_converter import BaseFormatConverter
 from chat_sdk.shared.errors import (
     AdapterError,
@@ -165,11 +180,29 @@ from chat_sdk.types import (
     WellKnownEmoji,
 )
 
+# The upstream Vercel Chat version this release is synced to.
+UPSTREAM_PARITY = "4.25.0"
+
 __all__ = [
+    "UPSTREAM_PARITY",
     # Core classes
     "Chat",
     "ThreadImpl",
     "ChannelImpl",
+    # Plan / PostableObject
+    "Plan",
+    "PlanTask",
+    "PlanTaskStatus",
+    "PlanModel",
+    "PlanModelTask",
+    "PlanContent",
+    "StartPlanOptions",
+    "AddTaskOptions",
+    "UpdateTaskInput",
+    "CompletePlanOptions",
+    "PostableObjectContext",
+    "is_postable_object",
+    "post_postable_object",
     # AI
     "to_ai_messages",
     # Card builders (PascalCase primary — matches source TS SDK)

--- a/src/chat_sdk/adapters/github/adapter.py
+++ b/src/chat_sdk/adapters/github/adapter.py
@@ -1,7 +1,7 @@
 """GitHub adapter for chat SDK.
 
-Supports both PR-level comments (Conversation tab) and review comment threads
-(Files Changed tab - line-specific).
+Supports PR-level comments (Conversation tab), review comment threads
+(Files Changed tab - line-specific), and issue comments.
 
 Python port of packages/adapter-github/src/index.ts.
 """
@@ -17,7 +17,7 @@ import re
 import time
 from collections.abc import AsyncIterable
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 from chat_sdk.adapters.github.cards import card_to_github_markdown
 from chat_sdk.adapters.github.format_converter import GitHubFormatConverter
@@ -59,6 +59,7 @@ from chat_sdk.types import (
 )
 
 REVIEW_COMMENT_THREAD_PATTERN = re.compile(r"^([^/]+)/([^:]+):(\d+):rc:(\d+)$")
+ISSUE_THREAD_PATTERN = re.compile(r"^([^/]+)/([^:]+):issue:(\d+)$")
 PR_THREAD_PATTERN = re.compile(r"^([^/]+)/([^:]+):(\d+)$")
 
 # GitHub reaction content types
@@ -261,7 +262,7 @@ class GitHubAdapter:
                 await self._store_installation_id(owner_login, repo_name, installation_id)
 
         if event_type == "issue_comment":
-            if payload.get("action") == "created" and payload.get("issue", {}).get("pull_request"):
+            if payload.get("action") == "created":
                 self._handle_issue_comment(payload, installation_id, options)
         elif event_type == "pull_request_review_comment" and payload.get("action") == "created":
             self._handle_review_comment(payload, installation_id, options)
@@ -291,7 +292,7 @@ class GitHubAdapter:
         installation_id: int | None,
         options: WebhookOptions | None = None,
     ) -> None:
-        """Handle issue_comment webhook (PR-level comments)."""
+        """Handle issue_comment webhook (PR-level or issue-level comments)."""
         if not self._chat:
             self._logger.warn("Chat instance not initialized, ignoring comment")
             return
@@ -301,15 +302,19 @@ class GitHubAdapter:
         repository = payload["repository"]
         sender = payload["sender"]
 
+        is_pr = bool(issue.get("pull_request"))
+        thread_type: Literal["pr", "issue"] = "pr" if is_pr else "issue"
+
         thread_id = self.encode_thread_id(
             GitHubThreadId(
                 owner=repository["owner"]["login"],
                 repo=repository["name"],
                 pr_number=issue["number"],
+                type=thread_type,
             )
         )
 
-        message = self._parse_issue_comment(comment, repository, issue["number"], thread_id)
+        message = self._parse_issue_comment(comment, repository, issue["number"], thread_id, thread_type)
 
         if sender.get("id") == self._bot_user_id:
             self._logger.debug("Ignoring message from self", {"messageId": comment["id"]})
@@ -358,6 +363,7 @@ class GitHubAdapter:
         repository: dict[str, Any],
         pr_number: int,
         thread_id: str,
+        thread_type: Literal["pr", "issue"] = "pr",
     ) -> Message:
         """Parse an issue comment into a normalized Message."""
         author = self._parse_author(comment["user"])
@@ -367,22 +373,25 @@ class GitHubAdapter:
         updated_at = comment.get("updated_at", "")
         edited = created_at != updated_at
 
+        raw: dict[str, Any] = {
+            "type": "issue_comment",
+            "comment": comment,
+            "repository": {
+                "id": 0,
+                "name": repository.get("name", ""),
+                "full_name": f"{repository.get('owner', {}).get('login', '')}/{repository.get('name', '')}",
+                "owner": repository.get("owner", {}),
+            },
+            "pr_number": pr_number,
+            "thread_type": thread_type,
+        }
+
         return Message(
             id=str(comment["id"]),
             thread_id=thread_id,
             text=self._format_converter.extract_plain_text(body_text),
             formatted=self._format_converter.to_ast(body_text),
-            raw={
-                "type": "issue_comment",
-                "comment": comment,
-                "repository": {
-                    "id": 0,
-                    "name": repository.get("name", ""),
-                    "full_name": f"{repository.get('owner', {}).get('login', '')}/{repository.get('name', '')}",
-                    "owner": repository.get("owner", {}),
-                },
-                "pr_number": pr_number,
-            },
+            raw=raw,
             author=author,
             metadata=MessageMetadata(
                 date_sent=_parse_iso(created_at) if created_at else datetime.now(tz=timezone.utc),
@@ -460,27 +469,31 @@ class GitHubAdapter:
                 {"body": body},
             )
         else:
-            # PR-level thread - issue comment
+            # PR-level or issue-level thread - issue comment
             comment = await self._github_api_request(
                 "POST",
                 f"/repos/{decoded.owner}/{decoded.repo}/issues/{decoded.pr_number}/comments",
                 {"body": body},
             )
 
+        raw: dict[str, Any] = {
+            "type": "review_comment" if decoded.review_comment_id else "issue_comment",
+            "comment": comment,
+            "repository": {
+                "id": 0,
+                "name": decoded.repo,
+                "full_name": f"{decoded.owner}/{decoded.repo}",
+                "owner": {"id": 0, "login": decoded.owner, "type": "User"},
+            },
+            "pr_number": decoded.pr_number,
+        }
+        if not decoded.review_comment_id:
+            raw["thread_type"] = decoded.type or "pr"
+
         return RawMessage(
             id=str(comment["id"]),
             thread_id=thread_id,
-            raw={
-                "type": "review_comment" if decoded.review_comment_id else "issue_comment",
-                "comment": comment,
-                "repository": {
-                    "id": 0,
-                    "name": decoded.repo,
-                    "full_name": f"{decoded.owner}/{decoded.repo}",
-                    "owner": {"id": 0, "login": decoded.owner, "type": "User"},
-                },
-                "pr_number": decoded.pr_number,
-            },
+            raw=raw,
         )
 
     async def edit_message(self, thread_id: str, message_id: str, message: AdapterPostableMessage) -> RawMessage:
@@ -505,20 +518,24 @@ class GitHubAdapter:
                 {"body": body},
             )
 
+        raw: dict[str, Any] = {
+            "type": "review_comment" if decoded.review_comment_id else "issue_comment",
+            "comment": comment,
+            "repository": {
+                "id": 0,
+                "name": decoded.repo,
+                "full_name": f"{decoded.owner}/{decoded.repo}",
+                "owner": {"id": 0, "login": decoded.owner, "type": "User"},
+            },
+            "pr_number": decoded.pr_number,
+        }
+        if not decoded.review_comment_id:
+            raw["thread_type"] = decoded.type or "pr"
+
         return RawMessage(
             id=str(comment["id"]),
             thread_id=thread_id,
-            raw={
-                "type": "review_comment" if decoded.review_comment_id else "issue_comment",
-                "comment": comment,
-                "repository": {
-                    "id": 0,
-                    "name": decoded.repo,
-                    "full_name": f"{decoded.owner}/{decoded.repo}",
-                    "owner": {"id": 0, "login": decoded.owner, "type": "User"},
-                },
-                "pr_number": decoded.pr_number,
-            },
+            raw=raw,
         )
 
     async def stream(
@@ -660,6 +677,7 @@ class GitHubAdapter:
                     {"owner": {"id": 0, "login": decoded.owner, "type": "User"}, "name": decoded.repo},
                     decoded.pr_number,
                     thread_id,
+                    decoded.type or "pr",
                 )
                 for c in comments
             ]
@@ -676,6 +694,27 @@ class GitHubAdapter:
     async def fetch_thread(self, thread_id: str) -> ThreadInfo:
         """Fetch thread metadata."""
         decoded = self.decode_thread_id(thread_id)
+
+        if decoded.type == "issue":
+            issue = await self._github_api_request(
+                "GET",
+                f"/repos/{decoded.owner}/{decoded.repo}/issues/{decoded.pr_number}",
+            )
+
+            return ThreadInfo(
+                id=thread_id,
+                channel_id=f"{decoded.owner}/{decoded.repo}",
+                channel_name=f"{decoded.repo} #{decoded.pr_number}",
+                is_dm=False,
+                metadata={
+                    "owner": decoded.owner,
+                    "repo": decoded.repo,
+                    "issueNumber": decoded.pr_number,
+                    "issueTitle": issue.get("title"),
+                    "issueState": issue.get("state"),
+                    "type": "issue",
+                },
+            )
 
         pr = await self._github_api_request(
             "GET",
@@ -698,7 +737,21 @@ class GitHubAdapter:
         )
 
     def encode_thread_id(self, platform_data: GitHubThreadId) -> str:
-        """Encode platform data into a thread ID string."""
+        """Encode platform data into a thread ID string.
+
+        Thread ID formats:
+        - PR-level: ``github:{owner}/{repo}:{prNumber}``
+        - Issue-level: ``github:{owner}/{repo}:issue:{issueNumber}``
+        - Review comment: ``github:{owner}/{repo}:{prNumber}:rc:{reviewCommentId}``
+        """
+        if platform_data.type == "issue" and platform_data.review_comment_id:
+            raise ValidationError(
+                "github",
+                "Review comments are not supported on issue threads",
+            )
+
+        if platform_data.type == "issue":
+            return f"github:{platform_data.owner}/{platform_data.repo}:issue:{platform_data.pr_number}"
         if platform_data.review_comment_id:
             return (
                 f"github:{platform_data.owner}/{platform_data.repo}"
@@ -720,6 +773,16 @@ class GitHubAdapter:
                 repo=rc_match.group(2),
                 pr_number=int(rc_match.group(3)),
                 review_comment_id=int(rc_match.group(4)),
+                type="pr",
+            )
+
+        issue_match = ISSUE_THREAD_PATTERN.match(without_prefix)
+        if issue_match:
+            return GitHubThreadId(
+                owner=issue_match.group(1),
+                repo=issue_match.group(2),
+                pr_number=int(issue_match.group(3)),
+                type="issue",
             )
 
         pr_match = PR_THREAD_PATTERN.match(without_prefix)
@@ -728,6 +791,7 @@ class GitHubAdapter:
                 owner=pr_match.group(1),
                 repo=pr_match.group(2),
                 pr_number=int(pr_match.group(3)),
+                type="pr",
             )
 
         raise ValidationError("github", f"Invalid GitHub thread ID format: {thread_id}")
@@ -779,6 +843,7 @@ class GitHubAdapter:
                         "owner": {"id": 0, "login": owner, "type": "User"},
                     },
                     "pr_number": pr["number"],
+                    "thread_type": "pr",
                 },
                 author=self._parse_author(pr_user),
                 metadata=MessageMetadata(
@@ -830,14 +895,18 @@ class GitHubAdapter:
     def parse_message(self, raw: GitHubRawMessage) -> Message:
         """Parse a raw message into normalized format."""
         if raw.get("type") == "issue_comment":
+            thread_type = raw.get("thread_type", "pr") or "pr"
             thread_id = self.encode_thread_id(
                 GitHubThreadId(
                     owner=raw["repository"]["owner"]["login"],
                     repo=raw["repository"]["name"],
                     pr_number=raw["pr_number"],
+                    type=thread_type,
                 )
             )
-            return self._parse_issue_comment(raw["comment"], raw["repository"], raw["pr_number"], thread_id)
+            return self._parse_issue_comment(
+                raw["comment"], raw["repository"], raw["pr_number"], thread_id, thread_type
+            )
         else:
             root_comment_id = raw["comment"].get("in_reply_to_id") or raw["comment"]["id"]
             thread_id = self.encode_thread_id(

--- a/src/chat_sdk/adapters/github/types.py
+++ b/src/chat_sdk/adapters/github/types.py
@@ -98,13 +98,17 @@ class GitHubThreadId:
     - PR-level: Comments in the "Conversation" tab (issue_comment API)
     - Review comment: Line-specific comments in "Files changed" tab
       (pull request review comment API)
+    - Issue-level: Comments on GitHub issues (issue_comment API)
     """
 
     owner: str
     """Repository owner (user or organization)."""
 
     pr_number: int
-    """Pull request number."""
+    """Issue or pull request number.
+
+    GitHub uses a shared number space, so this works for both PRs and issues.
+    """
 
     repo: str
     """Repository name."""
@@ -113,7 +117,17 @@ class GitHubThreadId:
     """Root review comment ID for line-specific threads.
 
     If present, this is a review comment thread.
-    If absent, this is a PR-level (issue comment) thread.
+    If absent, this is a PR-level or issue-level comment thread.
+    Only valid when type is "pr" or omitted.
+    """
+
+    type: Literal["pr", "issue"] | None = None
+    """Thread context type.
+
+    - "pr": PR conversation tab or review comment thread (default)
+    - "issue": GitHub issue comment thread
+
+    Omitting this field is equivalent to "pr" for backward compatibility.
     """
 
 
@@ -269,13 +283,18 @@ class PullRequestReviewCommentWebhookPayload(TypedDict, total=False):
 # =============================================================================
 
 
-class GitHubRawIssueComment(TypedDict):
+class GitHubRawIssueComment(TypedDict, total=False):
     """Platform-specific raw message for issue comments."""
 
-    type: Literal["issue_comment"]
-    comment: GitHubIssueComment
-    repository: GitHubRepository
-    pr_number: int
+    type: Literal["issue_comment"]  # required
+    comment: GitHubIssueComment  # required
+    repository: GitHubRepository  # required
+    pr_number: int  # required
+    thread_type: Literal["pr", "issue"]
+    """Whether this comment is on a PR or a plain issue.
+
+    Defaults to "pr" when omitted for backward compatibility.
+    """
 
 
 class GitHubRawReviewComment(TypedDict):

--- a/src/chat_sdk/adapters/slack/adapter.py
+++ b/src/chat_sdk/adapters/slack/adapter.py
@@ -416,8 +416,18 @@ class SlackAdapter:
             team_name=team_name,
         )
 
-    async def handle_oauth_callback(self, request: Any) -> dict[str, Any]:
+    async def handle_oauth_callback(
+        self,
+        request: Any,
+        options: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """Handle the Slack OAuth V2 callback.
+
+        Args:
+            request: The incoming HTTP request containing the OAuth callback.
+            options: Optional dict with ``redirect_uri`` key to send to Slack
+                during the code exchange. When provided it takes priority over
+                any ``redirect_uri`` query parameter in the callback URL.
 
         Returns ``{"team_id": ..., "installation": SlackInstallation}``.
         """
@@ -432,14 +442,14 @@ class SlackAdapter:
         if isinstance(url, str) and "?" in url:
             query = dict(parse_qs(url.split("?", 1)[1]))
             code = query.get("code", [None])[0] if isinstance(query.get("code"), list) else query.get("code")
-            redirect_uri = (
+            query_redirect_uri = (
                 query.get("redirect_uri", [None])[0]
                 if isinstance(query.get("redirect_uri"), list)
                 else query.get("redirect_uri")
             )
         else:
             code = None
-            redirect_uri = None
+            query_redirect_uri = None
 
         if not code:
             raise ValidationError(
@@ -447,13 +457,18 @@ class SlackAdapter:
                 "Missing 'code' query parameter in OAuth callback request.",
             )
 
+        # Options redirect_uri takes priority over the query param
+        redirect_uri = (options or {}).get("redirect_uri") or query_redirect_uri
+
         client = self._get_client("")
-        result = await client.oauth_v2_access(
-            client_id=self._client_id,
-            client_secret=self._client_secret,
-            code=code,
-            redirect_uri=redirect_uri,
-        )
+        kwargs: dict[str, Any] = {
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+            "code": code,
+        }
+        if redirect_uri:
+            kwargs["redirect_uri"] = redirect_uri
+        result = await client.oauth_v2_access(**kwargs)
 
         if not (result.get("ok") and result.get("access_token") and result.get("team", {}).get("id")):
             raise AuthenticationError(
@@ -2023,7 +2038,7 @@ class SlackAdapter:
         # Use StreamingMarkdownRenderer for safe incremental rendering
         from chat_sdk.shared.streaming_markdown import StreamingMarkdownRenderer
 
-        renderer = StreamingMarkdownRenderer()
+        renderer = StreamingMarkdownRenderer(wrap_tables_for_append=False)
         structured_chunks_supported = True
 
         async def flush_markdown_delta(delta: str) -> None:

--- a/src/chat_sdk/adapters/teams/cards.py
+++ b/src/chat_sdk/adapters/teams/cards.py
@@ -22,9 +22,14 @@ from chat_sdk.cards import (
     card_child_to_fallback_text,
 )
 from chat_sdk.emoji import convert_emoji_placeholders
+from chat_sdk.modals import RadioSelectElement, SelectElement
 
 ADAPTIVE_CARD_SCHEMA = "http://adaptivecards.io/schemas/adaptive-card.json"
 ADAPTIVE_CARD_VERSION = "1.4"
+
+# Sentinel action ID for auto-injected submit buttons.
+# Used when a card has select/radio_select inputs but no submit button.
+AUTO_SUBMIT_ACTION_ID = "__auto_submit"
 
 
 def _convert_emoji(text: str) -> str:
@@ -174,16 +179,93 @@ def _convert_image_to_element(element: ImageElement) -> dict[str, Any]:
 
 
 def _convert_actions_to_elements(element: ActionsElement) -> dict[str, Any]:
-    """Convert actions to Adaptive Card actions (card-level, not inline)."""
+    """Convert actions to Adaptive Card actions (card-level, not inline).
+
+    Select and RadioSelect elements become Input.ChoiceSet body elements.
+    When inputs are present but no explicit buttons, an auto-submit
+    Action.Submit is injected (Teams inputs need an explicit submit action).
+    """
     actions: list[dict[str, Any]] = []
+    elements: list[dict[str, Any]] = []
+    has_buttons = False
+    has_inputs = False
+
     for child in element.get("children", []):
         child_type = child.get("type", "")
-        if child_type == "link-button":
-            actions.append(_convert_link_button_to_action(child))  # type: ignore[arg-type]
-        elif child_type == "button":
+        if child_type == "button":
+            has_buttons = True
             actions.append(_convert_button_to_action(child))  # type: ignore[arg-type]
+        elif child_type == "link-button":
+            actions.append(_convert_link_button_to_action(child))  # type: ignore[arg-type]
+        elif child_type == "select":
+            has_inputs = True
+            elements.append(_convert_select_to_element(child))  # type: ignore[arg-type]
+        elif child_type == "radio_select":
+            has_inputs = True
+            elements.append(_convert_radio_select_to_element(child))  # type: ignore[arg-type]
 
-    return {"elements": [], "actions": actions}
+    # Auto-inject a submit button when there are inputs but no buttons.
+    # Teams inputs don't auto-submit like Slack -- they need an Action.Submit.
+    if has_inputs and not has_buttons:
+        actions.append(
+            {
+                "type": "Action.Submit",
+                "title": "Submit",
+                "data": {"actionId": AUTO_SUBMIT_ACTION_ID},
+            }
+        )
+
+    return {"elements": elements, "actions": actions}
+
+
+def _convert_select_to_element(select: SelectElement) -> dict[str, Any]:
+    """Convert a SelectElement to an Adaptive Card Input.ChoiceSet (compact)."""
+    choices = [
+        {"title": _convert_emoji(opt.get("label", "")), "value": opt.get("value", "")}
+        for opt in select.get("options", [])
+    ]
+
+    result: dict[str, Any] = {
+        "type": "Input.ChoiceSet",
+        "id": select.get("id", ""),
+        "label": _convert_emoji(select.get("label", "")),
+        "style": "compact",
+        "isRequired": not select.get("optional", False),
+        "choices": choices,
+    }
+
+    placeholder = select.get("placeholder")
+    if placeholder:
+        result["placeholder"] = placeholder
+
+    initial_option = select.get("initial_option")
+    if initial_option:
+        result["value"] = initial_option
+
+    return result
+
+
+def _convert_radio_select_to_element(radio_select: RadioSelectElement) -> dict[str, Any]:
+    """Convert a RadioSelectElement to an Adaptive Card Input.ChoiceSet (expanded)."""
+    choices = [
+        {"title": _convert_emoji(opt.get("label", "")), "value": opt.get("value", "")}
+        for opt in radio_select.get("options", [])
+    ]
+
+    result: dict[str, Any] = {
+        "type": "Input.ChoiceSet",
+        "id": radio_select.get("id", ""),
+        "label": _convert_emoji(radio_select.get("label", "")),
+        "style": "expanded",
+        "isRequired": not radio_select.get("optional", False),
+        "choices": choices,
+    }
+
+    initial_option = radio_select.get("initial_option")
+    if initial_option:
+        result["value"] = initial_option
+
+    return result
 
 
 def _convert_button_to_action(button: ButtonElement) -> dict[str, Any]:

--- a/src/chat_sdk/channel.py
+++ b/src/chat_sdk/channel.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from chat_sdk.errors import ChatNotImplementedError
+from chat_sdk.plan import is_postable_object, post_postable_object
 from chat_sdk.thread import (
     _ChannelImplConfigForThread,
     _ChatSingleton,
@@ -271,13 +272,20 @@ class ChannelImpl:
 
     async def post(
         self,
-        message: PostableMessage,
-    ) -> SentMessage:
+        message: PostableMessage | Any,
+    ) -> SentMessage | Any:
         """Post a message to this channel.
 
         If the message is an AsyncIterable (streaming), accumulates all text
         and posts as a single message -- channels do not support real-time streaming.
+
+        If the message is a PostableObject (e.g. Plan), it is posted via
+        native adapter support or fallback text.
         """
+        if is_postable_object(message):
+            await self._handle_postable_object(message)
+            return message
+
         if _is_async_iterable(message):
             accumulated = ""
             async for chunk in _from_full_stream(message):
@@ -303,6 +311,17 @@ class ChannelImpl:
             await self._message_history.append(self._id, _to_message(sent))
 
         return sent
+
+    async def _handle_postable_object(self, obj: Any) -> None:
+        """Post a PostableObject using native adapter support or fallback."""
+        adapter = self.adapter
+
+        async def _post_fn(thread_id: str, message: str) -> Any:
+            if hasattr(adapter, "post_channel_message") and adapter.post_channel_message:
+                return await adapter.post_channel_message(thread_id, message)
+            return await adapter.post_message(thread_id, message)
+
+        await post_postable_object(obj, adapter, self._id, _post_fn)
 
     async def post_ephemeral(
         self,

--- a/src/chat_sdk/plan.py
+++ b/src/chat_sdk/plan.py
@@ -1,0 +1,430 @@
+"""Plan implementation for chat-sdk.
+
+Python port of Vercel Chat SDK plan.ts and postable-object.ts.
+Provides the Plan class (a PostableObject that manages a task list),
+and the ``post_postable_object`` helper used by Thread/Channel to post
+any PostableObject.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from chat_sdk.logger import Logger
+from chat_sdk.types import Adapter
+
+# =============================================================================
+# Plan Types
+# =============================================================================
+
+PlanTaskStatus = Literal["pending", "in_progress", "complete", "error"]
+
+
+@dataclass
+class PlanTask:
+    """Public view of a plan task (id, title, status)."""
+
+    id: str
+    title: str
+    status: PlanTaskStatus
+
+
+@dataclass
+class PlanModelTask:
+    """Internal model of a plan task with optional details/output."""
+
+    id: str
+    title: str
+    status: PlanTaskStatus
+    details: PlanContent | None = None
+    output: PlanContent | None = None
+
+
+PlanContent = str | list[str] | dict[str, Any]
+"""Content that can be plain text, a list of strings, or ``{"markdown": ...}``/``{"ast": ...}``."""
+
+
+@dataclass
+class PlanModel:
+    """Internal plan model with title and tasks."""
+
+    title: str
+    tasks: list[PlanModelTask] = field(default_factory=list)
+
+
+@dataclass
+class StartPlanOptions:
+    """Options for starting a new plan."""
+
+    initial_message: PlanContent
+
+
+@dataclass
+class AddTaskOptions:
+    """Options for adding a task to a plan."""
+
+    title: PlanContent
+    children: PlanContent | None = None
+
+
+@dataclass
+class UpdateTaskInput:
+    """Structured update input with optional output and status override."""
+
+    output: PlanContent | None = None
+    status: PlanTaskStatus | None = None
+
+
+@dataclass
+class CompletePlanOptions:
+    """Options for completing a plan."""
+
+    complete_message: PlanContent
+
+
+# =============================================================================
+# PostableObject context
+# =============================================================================
+
+
+@dataclass
+class PostableObjectContext:
+    """Context provided to a PostableObject after it has been posted."""
+
+    adapter: Adapter
+    message_id: str
+    thread_id: str
+    logger: Logger | None = None
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _content_to_plain_text(content: PlanContent | None) -> str:
+    """Convert PlanContent to plain text for titles/labels."""
+    if content is None:
+        return ""
+    if isinstance(content, list):
+        return " ".join(content).strip()
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict) and "markdown" in content:
+        return content["markdown"]
+    if isinstance(content, dict):
+        # For ast dicts, return empty -- full rendering not needed for titles
+        pass
+    return ""
+
+
+def is_postable_object(value: Any) -> bool:
+    """Check if a value is a PostableObject (has the required protocol methods)."""
+    return (
+        isinstance(value, object)
+        and hasattr(value, "kind")
+        and hasattr(value, "get_fallback_text")
+        and hasattr(value, "get_post_data")
+        and hasattr(value, "is_supported")
+        and hasattr(value, "on_posted")
+    )
+
+
+# =============================================================================
+# post_postable_object — shared helper for Thread & Channel
+# =============================================================================
+
+
+async def post_postable_object(
+    obj: Any,
+    adapter: Adapter,
+    thread_id: str,
+    post_fn: Any,
+    logger: Logger | None = None,
+) -> None:
+    """Post a PostableObject using the adapter's native support or fallback text.
+
+    Parameters
+    ----------
+    obj:
+        The PostableObject to post.
+    adapter:
+        The adapter to use.
+    thread_id:
+        Thread or channel ID to post to.
+    post_fn:
+        Async callable ``(thread_id, message) -> RawMessage`` used for posting.
+    logger:
+        Optional logger for error reporting.
+    """
+
+    def _make_context(raw: Any) -> PostableObjectContext:
+        return PostableObjectContext(
+            adapter=adapter,
+            logger=logger,
+            message_id=raw.id,
+            thread_id=getattr(raw, "thread_id", None) or thread_id,
+        )
+
+    if obj.is_supported(adapter) and hasattr(adapter, "post_object") and adapter.post_object:
+        raw = await adapter.post_object(thread_id, obj.kind, obj.get_post_data())
+        obj.on_posted(_make_context(raw))
+    else:
+        raw = await post_fn(thread_id, obj.get_fallback_text())
+        obj.on_posted(_make_context(raw))
+
+
+# =============================================================================
+# Bound state for a posted Plan
+# =============================================================================
+
+
+@dataclass
+class _BoundState:
+    adapter: Adapter
+    fallback: bool
+    message_id: str
+    thread_id: str
+    logger: Logger | None = None
+    update_chain: asyncio.Future[None] | None = None
+
+
+# =============================================================================
+# Plan
+# =============================================================================
+
+
+class Plan:
+    """A Plan represents a task list that can be posted to a thread.
+
+    Create a plan with ``Plan(StartPlanOptions(initial_message="..."))``
+    and post it with ``await thread.post(plan)``.
+
+    After posting, use methods like ``add_task()``, ``update_task()``,
+    and ``complete()`` to update it.
+
+    Example::
+
+        plan = Plan(StartPlanOptions(initial_message="Starting task..."))
+        await thread.post(plan)
+        await plan.add_task(AddTaskOptions(title="Fetch data"))
+        await plan.update_task("Got 42 results")
+        await plan.complete(CompletePlanOptions(complete_message="Done!"))
+    """
+
+    kind: str = "plan"
+
+    def __init__(self, options: StartPlanOptions) -> None:
+        title = _content_to_plain_text(options.initial_message) or "Plan"
+        first_task = PlanModelTask(
+            id=str(uuid.uuid4()),
+            title=title,
+            status="in_progress",
+        )
+        self._model = PlanModel(title=title, tasks=[first_task])
+        self._bound: _BoundState | None = None
+
+    # -- PostableObject protocol ------------------------------------------------
+
+    def is_supported(self, adapter: Adapter) -> bool:
+        """Check if the adapter supports native plan rendering."""
+        return (
+            hasattr(adapter, "post_object")
+            and adapter.post_object is not None  # type: ignore[union-attr]
+            and hasattr(adapter, "edit_object")
+            and adapter.edit_object is not None  # type: ignore[union-attr]
+        )
+
+    def get_post_data(self) -> PlanModel:
+        """Get the plan model data for the adapter."""
+        return self._model
+
+    def get_fallback_text(self) -> str:
+        """Get a plain-text fallback representation of the plan."""
+        lines: list[str] = []
+        lines.append(f"\U0001f4cb {self._model.title or 'Plan'}")
+        status_icons: dict[str, str] = {
+            "complete": "\u2705",
+            "in_progress": "\U0001f504",
+            "error": "\u274c",
+        }
+        for task in self._model.tasks:
+            icon = status_icons.get(task.status, "\u2b1c")
+            lines.append(f"{icon} {task.title}")
+        return "\n".join(lines)
+
+    def on_posted(self, context: PostableObjectContext) -> None:
+        """Bind this plan to a posted message so subsequent mutations update it."""
+        self._bound = _BoundState(
+            adapter=context.adapter,
+            fallback=not self.is_supported(context.adapter),
+            logger=context.logger,
+            message_id=context.message_id,
+            thread_id=context.thread_id,
+        )
+
+    # -- Read-only properties ---------------------------------------------------
+
+    @property
+    def id(self) -> str:
+        return self._bound.message_id if self._bound else ""
+
+    @property
+    def thread_id(self) -> str:
+        return self._bound.thread_id if self._bound else ""
+
+    @property
+    def title(self) -> str:
+        return self._model.title
+
+    @property
+    def tasks(self) -> list[PlanTask]:
+        return [PlanTask(id=t.id, title=t.title, status=t.status) for t in self._model.tasks]
+
+    @property
+    def current_task(self) -> PlanTask | None:
+        """Get the current (last in-progress) task, or the last task."""
+        current: PlanModelTask | None = None
+        for t in reversed(self._model.tasks):
+            if t.status == "in_progress":
+                current = t
+                break
+        if current is None and self._model.tasks:
+            current = self._model.tasks[-1]
+        if current is None:
+            return None
+        return PlanTask(id=current.id, title=current.title, status=current.status)
+
+    # -- Mutations --------------------------------------------------------------
+
+    async def add_task(self, options: AddTaskOptions) -> PlanTask | None:
+        """Add a new task to the plan.
+
+        Marks all in-progress tasks as complete and adds a new in-progress task.
+        """
+        if not self._can_mutate():
+            return None
+        title = _content_to_plain_text(options.title) or "Task"
+        for task in self._model.tasks:
+            if task.status == "in_progress":
+                task.status = "complete"
+        next_task = PlanModelTask(
+            id=str(uuid.uuid4()),
+            title=title,
+            status="in_progress",
+            details=options.children,
+        )
+        self._model.tasks.append(next_task)
+        self._model.title = title
+
+        await self._enqueue_edit()
+        return PlanTask(id=next_task.id, title=next_task.title, status=next_task.status)
+
+    async def update_task(self, update: PlanContent | UpdateTaskInput | None = None) -> PlanTask | None:
+        """Update the current in-progress task.
+
+        ``update`` can be:
+        - ``PlanContent`` (str, list, dict) -- sets the task output
+        - ``UpdateTaskInput`` -- sets output and/or status
+        - ``None`` -- just triggers a re-render
+        """
+        if not self._can_mutate():
+            return None
+        current: PlanModelTask | None = None
+        for t in reversed(self._model.tasks):
+            if t.status == "in_progress":
+                current = t
+                break
+        if current is None and self._model.tasks:
+            current = self._model.tasks[-1]
+        if current is None:
+            return None
+
+        if update is not None:
+            if isinstance(update, UpdateTaskInput):
+                if update.output is not None:
+                    current.output = update.output
+                if update.status is not None:
+                    current.status = update.status
+            else:
+                # PlanContent
+                current.output = update
+
+        await self._enqueue_edit()
+        return PlanTask(id=current.id, title=current.title, status=current.status)
+
+    async def reset(self, options: StartPlanOptions) -> PlanTask | None:
+        """Reset the plan to a single new task."""
+        if not self._can_mutate():
+            return None
+        title = _content_to_plain_text(options.initial_message) or "Plan"
+        first_task = PlanModelTask(
+            id=str(uuid.uuid4()),
+            title=title,
+            status="in_progress",
+        )
+        self._model = PlanModel(title=title, tasks=[first_task])
+        await self._enqueue_edit()
+        return PlanTask(id=first_task.id, title=first_task.title, status=first_task.status)
+
+    async def complete(self, options: CompletePlanOptions) -> None:
+        """Mark the plan as complete.
+
+        Sets all in-progress tasks to complete and updates the title.
+        """
+        if not self._can_mutate():
+            return
+        for task in self._model.tasks:
+            if task.status == "in_progress":
+                task.status = "complete"
+        self._model.title = _content_to_plain_text(options.complete_message) or self._model.title
+        await self._enqueue_edit()
+
+    # -- Internal ---------------------------------------------------------------
+
+    def _can_mutate(self) -> bool:
+        return self._bound is not None
+
+    async def _enqueue_edit(self) -> None:
+        """Edit the posted message with the current plan state.
+
+        Chains edits sequentially to avoid race conditions.
+        """
+        if self._bound is None:
+            return
+
+        bound = self._bound
+
+        async def _do_edit() -> None:
+            if bound.fallback:
+                await bound.adapter.edit_message(
+                    bound.thread_id,
+                    bound.message_id,
+                    self.get_fallback_text(),
+                )
+            else:
+                edit_object = getattr(bound.adapter, "edit_object", None)
+                if edit_object is None:
+                    return
+                await edit_object(
+                    bound.thread_id,
+                    bound.message_id,
+                    self.kind,
+                    self._model,
+                )
+
+        # Chain edits: wait for previous edit to finish before starting new one
+        if bound.update_chain is not None:
+            with contextlib.suppress(Exception):
+                await bound.update_chain
+
+        try:
+            bound.update_chain = asyncio.ensure_future(_do_edit())
+            await bound.update_chain
+        except Exception as exc:
+            if bound.logger:
+                bound.logger.warn("Failed to edit plan", exc)

--- a/src/chat_sdk/shared/streaming_markdown.py
+++ b/src/chat_sdk/shared/streaming_markdown.py
@@ -349,7 +349,7 @@ class StreamingMarkdownRenderer:
     in the adapter's ``edit_message -> render_postable -> from_ast`` pipeline.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, wrap_tables_for_append: bool = True) -> None:
         self._accumulated = ""
         self._dirty = True
         self._cached_render = ""
@@ -358,6 +358,9 @@ class StreamingMarkdownRenderer:
         self._fence_toggles = 0
         # Incomplete trailing line buffer for incremental fence tracking
         self._incomplete_line = ""
+        # When True, confirmed tables are wrapped in code fences for
+        # append-only consumers that cannot render GFM tables natively.
+        self._wrap_tables_for_append = wrap_tables_for_append
 
     # -- public API ----------------------------------------------------------
 
@@ -405,13 +408,13 @@ class StreamingMarkdownRenderer:
         """Get text safe for append-only streaming (e.g. Slack native streaming).
 
         - Holds back unconfirmed table headers until separator arrives.
-        - Wraps confirmed tables in code fences so pipes render as literal
-          text (not broken mrkdwn).
+        - Optionally wraps confirmed tables in code fences so pipes render as
+          literal text on append-only surfaces that lack native table support.
         - Holds back unclosed inline markers.
         - The final ``edit_message`` replaces everything with properly formatted text.
         """
         if self._finished:
-            return _wrap_tables_for_append(self._accumulated, close_fences=True)
+            return self._format_append_only_text(self._accumulated, close_fences=True)
 
         text = self._accumulated
         if text and not text.endswith("\n"):
@@ -420,16 +423,20 @@ class StreamingMarkdownRenderer:
 
             # If stripping puts us inside a code fence, keep the incomplete line
             if _is_inside_code_fence(without_incomplete_line):
-                return _wrap_tables_for_append(text)
+                # Still apply any configured table transformation to preserve
+                # append-only coordinate space for delta calculation.
+                return self._format_append_only_text(text)
 
             text = without_incomplete_line
 
         # Inside a user code fence: skip table holding and inline marker buffering
+        # (pipes and markers are literal inside fences), but still apply any
+        # configured table transformation to preserve coordinate space.
         if _is_inside_code_fence(text):
-            return _wrap_tables_for_append(text)
+            return self._format_append_only_text(text)
 
         committed = _get_committable_prefix(text)
-        wrapped = _wrap_tables_for_append(committed)
+        wrapped = self._format_append_only_text(committed)
 
         # If text ends inside an open table code fence,
         # skip inline marker buffering
@@ -449,6 +456,12 @@ class StreamingMarkdownRenderer:
         return self.render()
 
     # -- private helpers -----------------------------------------------------
+
+    def _format_append_only_text(self, text: str, close_fences: bool = False) -> str:
+        """Conditionally wrap tables in code fences based on configuration."""
+        if not self._wrap_tables_for_append:
+            return text
+        return _wrap_tables_for_append(text, close_fences)
 
     def _is_accumulated_inside_fence(self) -> bool:
         """O(1) check if accumulated text is inside an unclosed code fence."""

--- a/src/chat_sdk/thread.py
+++ b/src/chat_sdk/thread.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from chat_sdk.errors import ChatNotImplementedError
 from chat_sdk.logger import Logger
+from chat_sdk.plan import is_postable_object, post_postable_object
 from chat_sdk.shared.streaming_markdown import StreamingMarkdownRenderer
 from chat_sdk.types import (
     THREAD_STATE_TTL_MS,
@@ -431,12 +432,19 @@ class ThreadImpl:
 
     async def post(
         self,
-        message: PostableMessage,
-    ) -> SentMessage:
+        message: PostableMessage | Any,
+    ) -> SentMessage | Any:
         """Post a message to this thread.
 
-        Accepts a plain string, PostableMessage, or an AsyncIterable for streaming.
+        Accepts a plain string, PostableMessage, AsyncIterable for streaming,
+        or a PostableObject (e.g. Plan). PostableObjects are returned directly
+        after posting so the caller can continue to mutate them.
         """
+        # Handle PostableObject (e.g. Plan)
+        if is_postable_object(message):
+            await self._handle_postable_object(message)
+            return message
+
         # Handle AsyncIterable (streaming)
         if _is_async_iterable(message):
             return await self._handle_stream(message)
@@ -449,6 +457,16 @@ class ThreadImpl:
             await self._message_history.append(self._id, _to_message(result))
 
         return result
+
+    async def _handle_postable_object(self, obj: Any) -> None:
+        """Post a PostableObject using native adapter support or fallback."""
+        await post_postable_object(
+            obj,
+            self.adapter,
+            self._id,
+            lambda thread_id, message: self.adapter.post_message(thread_id, message),
+            self._logger,
+        )
 
     async def post_ephemeral(
         self,

--- a/src/chat_sdk/types.py
+++ b/src/chat_sdk/types.py
@@ -713,7 +713,8 @@ class PostableCard:
 # Union of adapter-postable message types
 AdapterPostableMessage = str | PostableRaw | PostableMarkdown | PostableAst | PostableCard | CardElement
 
-# Union of all postable message types (includes streaming)
+# Union of all postable message types (includes streaming and PostableObjects)
+# PostableObject instances are detected at runtime via ``is_postable_object()``.
 PostableMessage = AdapterPostableMessage | AsyncIterable[Any]
 
 # =============================================================================

--- a/tests/test_github_extended.py
+++ b/tests/test_github_extended.py
@@ -566,6 +566,38 @@ class TestFetchThread:
         info = await adapter.fetch_thread(thread_id)
         assert info.metadata["review_comment_id"] == 200
 
+    @pytest.mark.asyncio
+    async def test_issue_thread_fetches_issue_metadata(self):
+        """fetch_thread for an issue thread uses the issues API, not pulls."""
+        adapter = _make_adapter()
+        adapter._github_api_request = AsyncMock(
+            return_value={
+                "title": "Bug report",
+                "state": "open",
+                "number": 10,
+            }
+        )
+
+        info = await adapter.fetch_thread("github:acme/app:issue:10")
+
+        # Verify the issues API was called (not pulls)
+        call = adapter._github_api_request.call_args
+        assert "/issues/10" in call[0][1]
+        assert "/pulls/" not in call[0][1]
+
+        assert info.id == "github:acme/app:issue:10"
+        assert info.channel_id == "acme/app"
+        assert info.channel_name == "app #10"
+        assert info.is_dm is False
+        assert info.metadata == {
+            "owner": "acme",
+            "repo": "app",
+            "issueNumber": 10,
+            "issueTitle": "Bug report",
+            "issueState": "open",
+            "type": "issue",
+        }
+
 
 # ---------------------------------------------------------------------------
 # Error handling

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -268,8 +268,8 @@ class TestGitHubWebhookMessageProcessing:
     """Issue comment / review comment processing via handleWebhook."""
 
     @pytest.mark.asyncio
-    async def test_issue_comment_not_on_pr_ignored(self):
-        """issue_comment on a plain issue (no pull_request key) is ignored."""
+    async def test_issue_comment_on_plain_issue_processed(self):
+        """issue_comment on a plain issue (no pull_request key) is processed."""
         adapter = _make_adapter()
         mock_chat = MagicMock()
         mock_chat.process_message = MagicMock()
@@ -282,6 +282,12 @@ class TestGitHubWebhookMessageProcessing:
             request = _make_request(body, "issue_comment", signature=sig)
             response = await adapter.handle_webhook(request)
             assert response["status"] == 200
+            mock_chat.process_message.assert_called_once()
+            call_args = mock_chat.process_message.call_args
+            assert call_args[0][1] == "github:acme/app:issue:10"
+            msg = call_args[0][2]
+            assert msg.id == "100"
+            assert msg.thread_id == "github:acme/app:issue:10"
         finally:
             await adapter.disconnect()
 
@@ -354,6 +360,60 @@ class TestGitHubParseMessage:
         assert msg.text == "Test comment"
         assert msg.author.user_name == "testuser"
         assert msg.author.is_bot is False
+
+    def test_issue_comment_from_issue_thread(self):
+        """Parse an issue_comment raw message from an issue thread."""
+        adapter = _make_adapter()
+        raw = {
+            "type": "issue_comment",
+            "comment": {
+                "id": 100,
+                "body": "Issue comment",
+                "user": {"id": 1, "login": "testuser", "type": "User"},
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "html_url": "https://github.com/acme/app/issues/10#issuecomment-100",
+            },
+            "repository": {
+                "id": 1,
+                "name": "app",
+                "full_name": "acme/app",
+                "owner": {"id": 10, "login": "acme", "type": "User"},
+            },
+            "pr_number": 10,
+            "thread_type": "issue",
+        }
+        msg = adapter.parse_message(raw)
+        assert msg.id == "100"
+        assert msg.thread_id == "github:acme/app:issue:10"
+        assert msg.text == "Issue comment"
+        assert msg.raw["type"] == "issue_comment"
+        assert msg.raw.get("thread_type") == "issue"
+
+    def test_default_to_pr_thread_when_thread_type_omitted(self):
+        """When thread_type is omitted, default to PR thread format."""
+        adapter = _make_adapter()
+        raw = {
+            "type": "issue_comment",
+            "comment": {
+                "id": 100,
+                "body": "Test comment",
+                "user": {"id": 1, "login": "testuser", "type": "User"},
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "html_url": "https://github.com/acme/app/pull/42#issuecomment-100",
+            },
+            "repository": {
+                "id": 1,
+                "name": "app",
+                "full_name": "acme/app",
+                "owner": {"id": 10, "login": "acme", "type": "User"},
+            },
+            "pr_number": 42,
+            # thread_type omitted -- should default to PR format
+        }
+        msg = adapter.parse_message(raw)
+        assert msg.thread_id == "github:acme/app:42"
 
     def test_review_comment_root(self):
         adapter = _make_adapter()
@@ -526,23 +586,84 @@ class TestGitHubThreadIdExtended:
         assert result.owner == "my-org"
         assert result.repo == "my-cool-app"
         assert result.pr_number == 42
+        assert result.type == "pr"
+
+    def test_decode_pr_thread(self):
+        adapter = _make_adapter()
+        result = adapter.decode_thread_id("github:acme/app:123")
+        assert result.owner == "acme"
+        assert result.repo == "app"
+        assert result.pr_number == 123
+        assert result.type == "pr"
+
+    def test_decode_review_comment_thread(self):
+        adapter = _make_adapter()
+        result = adapter.decode_thread_id("github:acme/app:123:rc:456789")
+        assert result.owner == "acme"
+        assert result.repo == "app"
+        assert result.pr_number == 123
+        assert result.type == "pr"
+        assert result.review_comment_id == 456789
+
+    def test_decode_issue_thread(self):
+        adapter = _make_adapter()
+        result = adapter.decode_thread_id("github:acme/app:issue:10")
+        assert result.owner == "acme"
+        assert result.repo == "app"
+        assert result.pr_number == 10
+        assert result.type == "issue"
+
+    def test_encode_issue_thread(self):
+        adapter = _make_adapter()
+        result = adapter.encode_thread_id(GitHubThreadId(owner="acme", repo="app", pr_number=10, type="issue"))
+        assert result == "github:acme/app:issue:10"
+
+    def test_encode_issue_thread_with_review_comment_raises(self):
+        adapter = _make_adapter()
+        with pytest.raises(ValidationError, match="Review comments are not supported on issue threads"):
+            adapter.encode_thread_id(
+                GitHubThreadId(
+                    owner="acme",
+                    repo="app",
+                    pr_number=10,
+                    type="issue",
+                    review_comment_id=999,
+                )
+            )
 
     def test_roundtrip_pr_level(self):
         adapter = _make_adapter()
-        original = GitHubThreadId(owner="vercel", repo="next.js", pr_number=99999)
+        original = GitHubThreadId(owner="vercel", repo="next.js", pr_number=99999, type="pr")
         decoded = adapter.decode_thread_id(adapter.encode_thread_id(original))
         assert decoded.owner == original.owner
         assert decoded.repo == original.repo
         assert decoded.pr_number == original.pr_number
+        assert decoded.type == "pr"
 
     def test_roundtrip_review_comment(self):
         adapter = _make_adapter()
-        original = GitHubThreadId(owner="vercel", repo="next.js", pr_number=99999, review_comment_id=123456789)
+        original = GitHubThreadId(
+            owner="vercel",
+            repo="next.js",
+            pr_number=99999,
+            review_comment_id=123456789,
+            type="pr",
+        )
         decoded = adapter.decode_thread_id(adapter.encode_thread_id(original))
         assert decoded.owner == original.owner
         assert decoded.repo == original.repo
         assert decoded.pr_number == original.pr_number
         assert decoded.review_comment_id == original.review_comment_id
+        assert decoded.type == "pr"
+
+    def test_roundtrip_issue_thread(self):
+        adapter = _make_adapter()
+        original = GitHubThreadId(owner="vercel", repo="next.js", pr_number=42, type="issue")
+        decoded = adapter.decode_thread_id(adapter.encode_thread_id(original))
+        assert decoded.owner == original.owner
+        assert decoded.repo == original.repo
+        assert decoded.pr_number == original.pr_number
+        assert decoded.type == "issue"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,501 @@
+"""Tests for Plan and PostableObject support.
+
+Covers:
+- Plan creation and initial state
+- PostableObject protocol detection (is_postable_object)
+- Posting a Plan to a thread (fallback path)
+- Posting a Plan to a channel (fallback path)
+- Plan mutations: add_task, update_task, complete, reset
+- Fallback text rendering
+- Mutations before posting (no-ops)
+- Native adapter path (post_object/edit_object)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from chat_sdk.channel import ChannelImpl, _ChannelImplConfigWithAdapter
+from chat_sdk.plan import (
+    AddTaskOptions,
+    CompletePlanOptions,
+    Plan,
+    PostableObjectContext,
+    StartPlanOptions,
+    UpdateTaskInput,
+    is_postable_object,
+    post_postable_object,
+)
+from chat_sdk.testing import (
+    MockAdapter,
+    MockStateAdapter,
+    create_mock_adapter,
+    create_mock_state,
+)
+from chat_sdk.thread import ThreadImpl, _ThreadImplConfig
+from chat_sdk.types import RawMessage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_thread(
+    adapter: MockAdapter | None = None,
+    state: MockStateAdapter | None = None,
+    *,
+    thread_id: str = "slack:C123:1234.5678",
+) -> ThreadImpl:
+    adapter = adapter or create_mock_adapter()
+    state = state or create_mock_state()
+    return ThreadImpl(
+        _ThreadImplConfig(
+            id=thread_id,
+            adapter=adapter,
+            state_adapter=state,
+        )
+    )
+
+
+def _make_channel(
+    adapter: MockAdapter | None = None,
+    state: MockStateAdapter | None = None,
+    *,
+    channel_id: str = "C123",
+) -> ChannelImpl:
+    adapter = adapter or create_mock_adapter()
+    state = state or create_mock_state()
+    return ChannelImpl(
+        _ChannelImplConfigWithAdapter(
+            id=channel_id,
+            adapter=adapter,
+            state_adapter=state,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_postable_object
+# ---------------------------------------------------------------------------
+
+
+class TestIsPostableObject:
+    def test_plan_is_postable_object(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        assert is_postable_object(plan) is True
+
+    def test_string_is_not_postable_object(self) -> None:
+        assert is_postable_object("hello") is False
+
+    def test_none_is_not_postable_object(self) -> None:
+        assert is_postable_object(None) is False
+
+    def test_dict_is_not_postable_object(self) -> None:
+        assert is_postable_object({"kind": "plan"}) is False
+
+    def test_plain_object_missing_methods(self) -> None:
+        class Incomplete:
+            kind = "plan"
+
+        assert is_postable_object(Incomplete()) is False
+
+
+# ---------------------------------------------------------------------------
+# Plan construction
+# ---------------------------------------------------------------------------
+
+
+class TestPlanConstruction:
+    def test_initial_state(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Starting..."))
+        assert plan.title == "Starting..."
+        assert plan.kind == "plan"
+        assert len(plan.tasks) == 1
+        assert plan.tasks[0].status == "in_progress"
+        assert plan.tasks[0].title == "Starting..."
+
+    def test_default_title(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message=""))
+        assert plan.title == "Plan"
+
+    def test_initial_message_list(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message=["Step", "1"]))
+        assert plan.title == "Step 1"
+
+    def test_initial_message_markdown_dict(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message={"markdown": "**Bold**"}))
+        assert plan.title == "**Bold**"
+
+    def test_current_task_is_first_task(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Task 1"))
+        assert plan.current_task is not None
+        assert plan.current_task.title == "Task 1"
+        assert plan.current_task.status == "in_progress"
+
+    def test_id_and_thread_id_empty_before_posting(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        assert plan.id == ""
+        assert plan.thread_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Fallback text
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackText:
+    def test_basic_fallback(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="My Plan"))
+        text = plan.get_fallback_text()
+        assert "\U0001f4cb My Plan" in text
+        assert "\U0001f504 My Plan" in text  # in_progress icon
+
+    @pytest.mark.asyncio
+    async def test_fallback_after_completion(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="My Plan"))
+        # Manually bind to allow mutations
+        plan.on_posted(
+            PostableObjectContext(
+                adapter=create_mock_adapter(),
+                message_id="msg-1",
+                thread_id="t1",
+            )
+        )
+        await plan.complete(CompletePlanOptions(complete_message="Done!"))
+        text = plan.get_fallback_text()
+        assert "\u2705" in text  # complete icon
+
+
+# ---------------------------------------------------------------------------
+# Mutations before posting (should no-op / return None)
+# ---------------------------------------------------------------------------
+
+
+class TestMutationsBeforePosting:
+    @pytest.mark.asyncio
+    async def test_add_task_before_post_returns_none(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        result = await plan.add_task(AddTaskOptions(title="Nope"))
+        assert result is None
+        assert len(plan.tasks) == 1  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_update_task_before_post_returns_none(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        result = await plan.update_task("output")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_complete_before_post_is_noop(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        await plan.complete(CompletePlanOptions(complete_message="Done"))
+        # Title should be unchanged since not bound
+        assert plan.title == "Test"
+
+    @pytest.mark.asyncio
+    async def test_reset_before_post_returns_none(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        result = await plan.reset(StartPlanOptions(initial_message="New"))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Posting via thread (fallback path)
+# ---------------------------------------------------------------------------
+
+
+class TestPostPlanToThread:
+    @pytest.mark.asyncio
+    async def test_post_plan_returns_plan(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Working..."))
+
+        result = await thread.post(plan)
+
+        assert result is plan
+        assert plan.id == "msg-1"
+        assert plan.thread_id == thread.id
+
+    @pytest.mark.asyncio
+    async def test_post_plan_calls_adapter_post_message(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Working..."))
+
+        await thread.post(plan)
+
+        assert len(adapter._post_calls) == 1
+        thread_id, message = adapter._post_calls[0]
+        assert thread_id == thread.id
+        assert isinstance(message, str)
+        assert "Working..." in message
+
+    @pytest.mark.asyncio
+    async def test_mutations_after_posting(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Step 1"))
+
+        await thread.post(plan)
+
+        # Add a task
+        task = await plan.add_task(AddTaskOptions(title="Step 2"))
+        assert task is not None
+        assert task.title == "Step 2"
+        assert task.status == "in_progress"
+        assert len(plan.tasks) == 2
+        assert plan.tasks[0].status == "complete"  # auto-completed
+
+        # Edit was called (fallback path)
+        assert len(adapter._edit_calls) >= 1
+
+    @pytest.mark.asyncio
+    async def test_update_task_sets_output(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Working"))
+        await thread.post(plan)
+
+        result = await plan.update_task("Got results")
+        assert result is not None
+        assert result.status == "in_progress"
+
+        # Check the internal model for output
+        assert plan._model.tasks[0].output == "Got results"
+
+    @pytest.mark.asyncio
+    async def test_update_task_with_structured_input(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Working"))
+        await thread.post(plan)
+
+        result = await plan.update_task(UpdateTaskInput(output="data", status="error"))
+        assert result is not None
+        assert result.status == "error"
+
+    @pytest.mark.asyncio
+    async def test_complete_marks_all_done(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Step 1"))
+        await thread.post(plan)
+
+        await plan.add_task(AddTaskOptions(title="Step 2"))
+        await plan.complete(CompletePlanOptions(complete_message="All done!"))
+
+        assert plan.title == "All done!"
+        for t in plan.tasks:
+            assert t.status == "complete"
+
+    @pytest.mark.asyncio
+    async def test_reset_replaces_all_tasks(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Step 1"))
+        await thread.post(plan)
+        await plan.add_task(AddTaskOptions(title="Step 2"))
+
+        result = await plan.reset(StartPlanOptions(initial_message="Fresh start"))
+        assert result is not None
+        assert result.title == "Fresh start"
+        assert len(plan.tasks) == 1
+        assert plan.tasks[0].status == "in_progress"
+
+    @pytest.mark.asyncio
+    async def test_current_task_tracks_in_progress(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Task 1"))
+        await thread.post(plan)
+
+        assert plan.current_task is not None
+        assert plan.current_task.title == "Task 1"
+
+        await plan.add_task(AddTaskOptions(title="Task 2"))
+        assert plan.current_task is not None
+        assert plan.current_task.title == "Task 2"
+
+
+# ---------------------------------------------------------------------------
+# Posting via channel (fallback path)
+# ---------------------------------------------------------------------------
+
+
+class TestPostPlanToChannel:
+    @pytest.mark.asyncio
+    async def test_post_plan_to_channel_returns_plan(self) -> None:
+        adapter = create_mock_adapter()
+        channel = _make_channel(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Channel plan"))
+
+        result = await channel.post(plan)
+
+        assert result is plan
+        assert plan.id != ""
+
+
+# ---------------------------------------------------------------------------
+# Native adapter path (post_object / edit_object)
+# ---------------------------------------------------------------------------
+
+
+class _NativeAdapter(MockAdapter):
+    """MockAdapter with post_object/edit_object support."""
+
+    def __init__(self) -> None:
+        super().__init__("native")
+        self._post_object_calls: list[tuple[str, str, Any]] = []
+        self._edit_object_calls: list[tuple[str, str, str, Any]] = []
+
+    async def post_object(self, thread_id: str, kind: str, data: Any) -> RawMessage:
+        self._post_object_calls.append((thread_id, kind, data))
+        return RawMessage(id="obj-1", thread_id=thread_id, raw={})
+
+    async def edit_object(self, thread_id: str, message_id: str, kind: str, data: Any) -> RawMessage:
+        self._edit_object_calls.append((thread_id, message_id, kind, data))
+        return RawMessage(id=message_id, thread_id=thread_id, raw={})
+
+
+class TestNativeAdapterPath:
+    @pytest.mark.asyncio
+    async def test_uses_post_object_when_supported(self) -> None:
+        adapter = _NativeAdapter()
+        state = create_mock_state()
+        thread = ThreadImpl(
+            _ThreadImplConfig(
+                id="t1",
+                adapter=adapter,
+                state_adapter=state,
+            )
+        )
+        plan = Plan(StartPlanOptions(initial_message="Native plan"))
+
+        result = await thread.post(plan)
+
+        assert result is plan
+        assert len(adapter._post_object_calls) == 1
+        assert adapter._post_object_calls[0][1] == "plan"
+        # Fallback post_message should NOT have been called
+        assert len(adapter._post_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_uses_edit_object_for_mutations(self) -> None:
+        adapter = _NativeAdapter()
+        state = create_mock_state()
+        thread = ThreadImpl(
+            _ThreadImplConfig(
+                id="t1",
+                adapter=adapter,
+                state_adapter=state,
+            )
+        )
+        plan = Plan(StartPlanOptions(initial_message="Native plan"))
+        await thread.post(plan)
+
+        await plan.add_task(AddTaskOptions(title="Step 2"))
+
+        assert len(adapter._edit_object_calls) >= 1
+        call = adapter._edit_object_calls[0]
+        assert call[1] == "obj-1"  # message_id
+        assert call[2] == "plan"  # kind
+
+    @pytest.mark.asyncio
+    async def test_is_supported_returns_true_for_native(self) -> None:
+        adapter = _NativeAdapter()
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        assert plan.is_supported(adapter) is True
+
+    @pytest.mark.asyncio
+    async def test_is_supported_returns_false_for_mock(self) -> None:
+        adapter = create_mock_adapter()
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        assert plan.is_supported(adapter) is False
+
+
+# ---------------------------------------------------------------------------
+# post_postable_object helper
+# ---------------------------------------------------------------------------
+
+
+class TestPostPostableObject:
+    @pytest.mark.asyncio
+    async def test_fallback_path(self) -> None:
+        adapter = create_mock_adapter()
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+
+        async def post_fn(thread_id: str, message: str) -> RawMessage:
+            return RawMessage(id="m1", thread_id=thread_id, raw={})
+
+        await post_postable_object(plan, adapter, "t1", post_fn)
+
+        assert plan.id == "m1"
+        assert plan.thread_id == "t1"
+
+    @pytest.mark.asyncio
+    async def test_native_path(self) -> None:
+        adapter = _NativeAdapter()
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+
+        async def post_fn(thread_id: str, message: str) -> RawMessage:
+            raise AssertionError("should not be called")
+
+        await post_postable_object(plan, adapter, "t1", post_fn)
+
+        assert plan.id == "obj-1"
+        assert len(adapter._post_object_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_multiple_add_tasks_mark_previous_complete(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Start"))
+        await thread.post(plan)
+
+        await plan.add_task(AddTaskOptions(title="Task 2"))
+        await plan.add_task(AddTaskOptions(title="Task 3"))
+
+        assert len(plan.tasks) == 3
+        assert plan.tasks[0].status == "complete"
+        assert plan.tasks[1].status == "complete"
+        assert plan.tasks[2].status == "in_progress"
+
+    @pytest.mark.asyncio
+    async def test_update_task_with_none(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Start"))
+        await thread.post(plan)
+
+        result = await plan.update_task(None)
+        assert result is not None
+        assert result.status == "in_progress"
+
+    @pytest.mark.asyncio
+    async def test_plan_get_post_data_returns_model(self) -> None:
+        plan = Plan(StartPlanOptions(initial_message="Test"))
+        data = plan.get_post_data()
+        assert data.title == "Test"
+        assert len(data.tasks) == 1
+
+    @pytest.mark.asyncio
+    async def test_add_task_with_children(self) -> None:
+        adapter = create_mock_adapter()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Start"))
+        await thread.post(plan)
+
+        task = await plan.add_task(AddTaskOptions(title="Sub", children=["a", "b"]))
+        assert task is not None
+        # Check internal model has details
+        assert plan._model.tasks[-1].details == ["a", "b"]

--- a/tests/test_slack_webhook.py
+++ b/tests/test_slack_webhook.py
@@ -51,9 +51,10 @@ def _slack_signature(body: str, secret: str, timestamp: int | None = None) -> tu
 class _FakeRequest:
     """Minimal request-like object for adapter webhook testing."""
 
-    def __init__(self, body: str, headers: dict[str, str] | None = None):
+    def __init__(self, body: str, headers: dict[str, str] | None = None, url: str = ""):
         self.body = body.encode("utf-8")
         self.headers = headers or {}
+        self.url = url
 
     async def text(self) -> str:
         return self.body.decode("utf-8")
@@ -690,3 +691,146 @@ class TestMultiWorkspace:
         assert await adapter.get_installation("T_TEAM_2") is not None
         await adapter.delete_installation("T_TEAM_2")
         assert await adapter.get_installation("T_TEAM_2") is None
+
+
+# ---------------------------------------------------------------------------
+# OAuth callback -- redirect_uri handling
+# ---------------------------------------------------------------------------
+
+
+def _make_oauth_adapter() -> tuple[SlackAdapter, MagicMock, AsyncMock]:
+    """Create a SlackAdapter wired for OAuth with a mocked oauth_v2_access."""
+    adapter = SlackAdapter(
+        SlackAdapterConfig(
+            signing_secret="test-signing-secret",
+            client_id="client-id",
+            client_secret="client-secret",
+        )
+    )
+    mock_access = AsyncMock(
+        return_value={
+            "ok": True,
+            "access_token": "xoxb-oauth-bot-token",
+            "bot_user_id": "U_BOT_OAUTH",
+            "team": {"id": "T_OAUTH_1", "name": "OAuth Team"},
+        }
+    )
+    # Patch the client returned by _get_client("") to have oauth_v2_access
+    mock_client = MagicMock()
+    mock_client.oauth_v2_access = mock_access
+    mock_client.auth_test = AsyncMock(
+        return_value={
+            "ok": True,
+            "user_id": "U_BOT_OAUTH",
+            "bot_id": "B_BOT",
+            "user": "bot",
+        }
+    )
+    adapter._client_cache[""] = mock_client
+    return adapter, mock_client, mock_access
+
+
+class TestOAuthRedirectUri:
+    """Port of upstream handleOAuthCallback redirect_uri tests (commit 1856198)."""
+
+    @pytest.mark.asyncio
+    async def test_exchanges_code_for_token_and_saves_installation(self):
+        adapter, _, mock_access = _make_oauth_adapter()
+        state = _make_mock_state()
+        await adapter.initialize(_make_mock_chat(state))
+
+        req = _FakeRequest(
+            "",
+            url="https://example.com/auth/callback/slack?code=oauth-code-123",
+        )
+        result = await adapter.handle_oauth_callback(req)
+
+        assert result["team_id"] == "T_OAUTH_1"
+        stored = await adapter.get_installation("T_OAUTH_1")
+        assert stored is not None
+        assert stored.bot_token == "xoxb-oauth-bot-token"
+        mock_access.assert_called_once_with(
+            client_id="client-id",
+            client_secret="client-secret",
+            code="oauth-code-123",
+        )
+
+    @pytest.mark.asyncio
+    async def test_forwards_redirect_uri_from_callback_options(self):
+        adapter, _, mock_access = _make_oauth_adapter()
+        state = _make_mock_state()
+        await adapter.initialize(_make_mock_chat(state))
+
+        req = _FakeRequest(
+            "",
+            url="https://example.com/auth/callback/slack?code=oauth-code-123",
+        )
+        await adapter.handle_oauth_callback(req, options={"redirect_uri": "https://example.com/install/callback"})
+
+        mock_access.assert_called_once_with(
+            client_id="client-id",
+            client_secret="client-secret",
+            code="oauth-code-123",
+            redirect_uri="https://example.com/install/callback",
+        )
+
+    @pytest.mark.asyncio
+    async def test_prefers_callback_options_redirect_uri_over_query_param(self):
+        adapter, _, mock_access = _make_oauth_adapter()
+        state = _make_mock_state()
+        await adapter.initialize(_make_mock_chat(state))
+
+        req = _FakeRequest(
+            "",
+            url="https://example.com/auth/callback/slack?code=oauth-code-123&redirect_uri=https%3A%2F%2Fexample.com%2Fquery-callback",
+        )
+        await adapter.handle_oauth_callback(req, options={"redirect_uri": "https://example.com/explicit-callback"})
+
+        mock_access.assert_called_once_with(
+            client_id="client-id",
+            client_secret="client-secret",
+            code="oauth-code-123",
+            redirect_uri="https://example.com/explicit-callback",
+        )
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_redirect_uri_from_query_param(self):
+        adapter, _, mock_access = _make_oauth_adapter()
+        state = _make_mock_state()
+        await adapter.initialize(_make_mock_chat(state))
+
+        req = _FakeRequest(
+            "",
+            url="https://example.com/auth/callback/slack?code=oauth-code-123&redirect_uri=https%3A%2F%2Fexample.com%2Fquery-callback",
+        )
+        await adapter.handle_oauth_callback(req)
+
+        mock_access.assert_called_once_with(
+            client_id="client-id",
+            client_secret="client-secret",
+            code="oauth-code-123",
+            redirect_uri="https://example.com/query-callback",
+        )
+
+    @pytest.mark.asyncio
+    async def test_throws_when_code_missing(self):
+        adapter, _, _ = _make_oauth_adapter()
+        state = _make_mock_state()
+        await adapter.initialize(_make_mock_chat(state))
+
+        req = _FakeRequest("", url="https://example.com/auth/callback/slack")
+        with pytest.raises(ValidationError, match="Missing 'code'"):
+            await adapter.handle_oauth_callback(req)
+
+    @pytest.mark.asyncio
+    async def test_throws_without_client_id_and_client_secret(self):
+        adapter = SlackAdapter(SlackAdapterConfig(signing_secret="test-secret"))
+        state = _make_mock_state()
+        await adapter.initialize(_make_mock_chat(state))
+
+        req = _FakeRequest(
+            "",
+            url="https://example.com/auth/callback/slack?code=abc",
+        )
+        with pytest.raises(ValidationError, match="client_id"):
+            await adapter.handle_oauth_callback(req)

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -22,12 +22,16 @@ CODE_FENCE_SPLIT_RE = re.compile(r"```|~~~")
 # ---------------------------------------------------------------------------
 
 
-def _simulate_append_stream(chunks: list[str]) -> dict[str, object]:
+def _simulate_append_stream(
+    chunks: list[str],
+    *,
+    wrap_tables_for_append: bool = True,
+) -> dict[str, object]:
     """Push chunks one at a time, computing deltas from get_committable_text().
 
     Returns dict with appendedText, finalText, and deltas list.
     """
-    r = StreamingMarkdownRenderer()
+    r = StreamingMarkdownRenderer(wrap_tables_for_append=wrap_tables_for_append)
     last_appended = ""
     deltas: list[str] = []
 
@@ -534,6 +538,26 @@ class TestAppendOnlyStreaming:
         # Intro should be outside the code fence
         assert text.index("Intro") < text.index("```")
 
+    def test_appendonly_table_can_stream_without_code_fence_when_wrapping_disabled(self):
+        result = _simulate_append_stream(
+            [
+                "Intro\n\n",
+                "| A | B |\n",
+                "|---|---|\n",
+                "| 1 | 2 |\n",
+                "| 3 | 4 |\n",
+                "\nAfter table\n",
+            ],
+            wrap_tables_for_append=False,
+        )
+        text = result["appendedText"]
+        assert isinstance(text, str)
+        assert "| A | B |" in text
+        assert "| 1 | 2 |" in text
+        assert "| 3 | 4 |" in text
+        assert "After table" in text
+        assert "```" not in text
+
     def test_appendonly_table_at_end_of_stream_is_flushed_on_finish(self):
         result = _simulate_append_stream(
             [
@@ -568,6 +592,28 @@ class TestAppendOnlyStreaming:
         assert "| c | d |" in text
         assert "Done" in text
         assert "```" in text
+
+    def test_appendonly_concatenated_deltas_equal_final_text_when_wrapping_disabled(self):
+        result = _simulate_append_stream(
+            [
+                "Hello **world**\n",
+                "\n",
+                "| H1 | H2 |\n",
+                "| - | - |\n",
+                "| a | b |\n",
+                "| c | d |\n",
+                "\nDone\n",
+            ],
+            wrap_tables_for_append=False,
+        )
+        text = result["appendedText"]
+        assert isinstance(text, str)
+        assert "Hello **world**" in text
+        assert "| H1 | H2 |" in text
+        assert "| a | b |" in text
+        assert "| c | d |" in text
+        assert "Done" in text
+        assert "```" not in text
 
     def test_appendonly_concatenated_deltas_are_monotonic_each_is_a_suffix(self):
         """Core invariant: concatenated deltas must equal final output."""

--- a/tests/test_teams_cards.py
+++ b/tests/test_teams_cards.py
@@ -5,7 +5,7 @@ Ported from packages/adapter-teams/src/cards.test.ts.
 
 from __future__ import annotations
 
-from chat_sdk.adapters.teams.cards import card_to_adaptive_card, card_to_fallback_text
+from chat_sdk.adapters.teams.cards import AUTO_SUBMIT_ACTION_ID, card_to_adaptive_card, card_to_fallback_text
 from chat_sdk.cards import (
     Actions,
     Button,
@@ -19,6 +19,7 @@ from chat_sdk.cards import (
     LinkButton,
     Section,
 )
+from chat_sdk.modals import RadioSelect, Select, SelectOption
 
 # ---------------------------------------------------------------------------
 # cardToAdaptiveCard
@@ -208,6 +209,117 @@ class TestCardToAdaptiveCard:
             "text": "[Click here](https://example.com)",
             "wrap": True,
         }
+
+
+# ---------------------------------------------------------------------------
+# Select and RadioSelect in Actions
+# ---------------------------------------------------------------------------
+
+
+class TestCardToAdaptiveCardSelectAndRadioSelect:
+    """Ported from cards.test.ts: cardToAdaptiveCard with select and radio_select in Actions."""
+
+    def test_converts_select_to_compact_choice_set_input(self):
+        card = Card(
+            children=[
+                Actions(
+                    [
+                        Select(
+                            id="color",
+                            label="Pick a color",
+                            options=[
+                                SelectOption(label="Red", value="red"),
+                                SelectOption(label="Blue", value="blue"),
+                            ],
+                            placeholder="Choose...",
+                        ),
+                    ]
+                ),
+            ],
+        )
+        adaptive = card_to_adaptive_card(card)
+
+        assert len(adaptive["body"]) == 1
+        choice_set = adaptive["body"][0]
+        assert choice_set["type"] == "Input.ChoiceSet"
+        assert choice_set["id"] == "color"
+        assert choice_set["label"] == "Pick a color"
+        assert choice_set["style"] == "compact"
+        assert choice_set["isRequired"] is True
+        assert choice_set["placeholder"] == "Choose..."
+
+        assert len(choice_set["choices"]) == 2
+        assert choice_set["choices"][0] == {"title": "Red", "value": "red"}
+        assert choice_set["choices"][1] == {"title": "Blue", "value": "blue"}
+
+        # Auto-injects submit button since there are no explicit buttons
+        assert len(adaptive["actions"]) == 1
+        assert adaptive["actions"][0] == {
+            "type": "Action.Submit",
+            "title": "Submit",
+            "data": {"actionId": AUTO_SUBMIT_ACTION_ID},
+        }
+
+    def test_converts_radio_select_to_expanded_choice_set_input(self):
+        card = Card(
+            children=[
+                Actions(
+                    [
+                        RadioSelect(
+                            id="plan",
+                            label="Choose Plan",
+                            options=[
+                                SelectOption(label="Free", value="free"),
+                                SelectOption(label="Pro", value="pro"),
+                            ],
+                        ),
+                    ]
+                ),
+            ],
+        )
+        adaptive = card_to_adaptive_card(card)
+
+        assert len(adaptive["body"]) == 1
+        choice_set = adaptive["body"][0]
+        assert choice_set["type"] == "Input.ChoiceSet"
+        assert choice_set["id"] == "plan"
+        assert choice_set["label"] == "Choose Plan"
+        assert choice_set["style"] == "expanded"
+        assert choice_set["isRequired"] is True
+
+        # Auto-injects submit button
+        assert len(adaptive["actions"]) == 1
+        assert adaptive["actions"][0] == {
+            "type": "Action.Submit",
+            "title": "Submit",
+            "data": {"actionId": AUTO_SUBMIT_ACTION_ID},
+        }
+
+    def test_does_not_auto_inject_submit_when_buttons_present(self):
+        card = Card(
+            children=[
+                Actions(
+                    [
+                        Select(
+                            id="color",
+                            label="Color",
+                            options=[SelectOption(label="Red", value="red")],
+                        ),
+                        Button(id="submit", label="Submit", style="primary"),
+                    ]
+                ),
+            ],
+        )
+        adaptive = card_to_adaptive_card(card)
+
+        # Select goes to body, button goes to actions
+        assert len(adaptive["body"]) == 1
+        assert adaptive["body"][0]["type"] == "Input.ChoiceSet"
+        assert adaptive["body"][0]["id"] == "color"
+
+        assert len(adaptive["actions"]) == 1
+        assert adaptive["actions"][0]["type"] == "Action.Submit"
+        assert adaptive["actions"][0]["title"] == "Submit"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Syncs the Python SDK to [Vercel Chat v4.25.0](https://github.com/vercel/chat). Introduces a new versioning scheme where our minor version tracks the upstream minor version.

### New features (from upstream)

- **Plan blocks**: `Plan` PostableObject for structured task lists with live updates via `add_task()`, `update_task()`, `complete()`. Renders as a Card with automatic edit-on-mutation.
- **Streaming table option**: `StreamingMarkdownRenderer(wrap_tables_for_append=False)` disables code-fence wrapping. Slack adapter uses this by default (Slack now supports native markdown tables).
- **Teams Select/RadioSelect**: Card elements render as Adaptive Card `Input.ChoiceSet` with auto-injected submit button.
- **GitHub issue threads**: `issue_comment` webhooks on plain issues create threads with format `github:owner/repo:issue:42`.
- **Slack OAuth redirect**: `handle_oauth_callback` correctly forwards `redirect_uri` option.

### Versioning

New scheme: `0.{upstream_minor}.{patch}`
- `0.25.0` = synced to upstream `4.25.0`
- `0.25.1` = Python-only fix
- `0.26.0` = synced to upstream `4.26.0`

`UPSTREAM_PARITY` constant in `chat_sdk.__init__` for programmatic access.

### Documentation

- CLAUDE.md: version mapping, thread ID formats, message handling flow, full validation command
- UPSTREAM_SYNC.md: step-by-step sync procedure with per-commit checklist
- CHANGELOG.md: public-facing release notes

## Test plan

- [x] `uv run ruff check src/ tests/ scripts/` — All checks passed
- [x] `uv run ruff format --check` — 190 files formatted
- [x] `verify_test_fidelity.py` — 535/535 (100%), 0 missing
- [x] `audit_test_quality.py` — 0 hard failures
- [x] `pytest` — 3416 passed, 2 skipped, 0 warnings
- [x] 56 new tests for upstream features

🤖 Generated with [Claude Code](https://claude.com/claude-code)