### PR TITLE
release: v0.4.25 — synced to Vercel Chat 4.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.25.0 (2026-04-10)
+## 0.4.25 (2026-04-10)
 
-Synced to [Vercel Chat 4.25.0](https://github.com/vercel/chat). New versioning: our minor version matches the upstream minor version.
+Synced to [Vercel Chat 4.25.0](https://github.com/vercel/chat). New versioning: `0.{upstream_major}.{upstream_minor}` embeds the upstream version directly.
 
 ### New features (from upstream 4.25.0)
 - **Plan blocks**: `Plan` PostableObject for structured task lists with live updates. Post a plan to a thread, then `add_task()`, `update_task()`, and `complete()` with automatic card rendering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Synced to [Vercel Chat 4.25.0](https://github.com/vercel/chat). New versioning: 
 - **Slack OAuth redirect fix**: `handle_oauth_callback` correctly forwards `redirect_uri` option.
 
 ### Versioning
-- Version scheme changed from `0.0.1aX` to `0.{upstream_minor}.{patch}`
+- Version scheme changed from `0.0.1aX` to `0.{upstream_major}.{upstream_minor}[.patch]`
 - `UPSTREAM_PARITY` constant in `chat_sdk.__init__` for programmatic access
 - Sync procedure documented in [UPSTREAM_SYNC.md](docs/UPSTREAM_SYNC.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,11 @@ uv run pytest tests/ --tb=short -q
 ```
 
 ## Version Mapping
-Our version tracks the upstream Vercel Chat minor version:
-- `0.25.0` = synced to upstream `4.25.0`
-- `0.25.1` = Python-only fixes on top of `4.25.0`
-- `0.26.0` = synced to upstream `4.26.0`
+Our version embeds the upstream Vercel Chat version: `0.{upstream_major}.{upstream_minor}[.patch]`
+- `0.4.25` = synced to upstream `4.25.0`
+- `0.4.25.1` = Python-only fix on top of `4.25.0`
+- `0.4.26` = synced to upstream `4.26.0`
+- `0.4.26a1` = alpha while porting upstream `4.26.0`
 - `UPSTREAM_PARITY` constant in `__init__.py` = programmatic access
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # chat-sdk-python
 
+[![PyPI](https://img.shields.io/pypi/v/chat-sdk)](https://pypi.org/project/chat-sdk/)
+[![Python](https://img.shields.io/pypi/pyversions/chat-sdk)](https://pypi.org/project/chat-sdk/)
+[![Tests](https://github.com/Chinchill-AI/chat-sdk-python/actions/workflows/test.yml/badge.svg)](https://github.com/Chinchill-AI/chat-sdk-python/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Multi-platform async chat SDK for Python. Port of [Vercel Chat](https://github.com/vercel/chat).
 
 > **Status: Alpha (0.4.25 — synced to [Vercel Chat 4.25.0](https://github.com/vercel/chat))** — API may change.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Multi-platform async chat SDK for Python. Port of [Vercel Chat](https://github.com/vercel/chat).
 
-> **Status: Alpha (0.25.0 — synced to [Vercel Chat 4.25.0](https://github.com/vercel/chat))** — API may change.
+> **Status: Alpha (0.4.25 — synced to [Vercel Chat 4.25.0](https://github.com/vercel/chat))** — API may change.
 
 ## Why chat-sdk?
 

--- a/docs/UPSTREAM_SYNC.md
+++ b/docs/UPSTREAM_SYNC.md
@@ -392,6 +392,8 @@ stay explicit instead of being rediscovered in code review.
 | `ast_to_plain_text` | Joins blocks with `\n` | Concatenates directly | More readable output |
 | `renderPostable` on unknown input | Returns `str(message)` | Throws `Error` | More resilient |
 | Chat resolver | 3-level: explicit → ContextVar → global | Process-global singleton | See [DECISIONS.md](DECISIONS.md#why-3-level-chat-resolver) |
+| PostableObject history | Cached in message history with real message ID | Not cached (skips history) | Upstream gap — posted messages should appear in thread/channel history |
+| Teams `msteams` transport key | Stripped from action values | Not stripped | Upstream gap — SDK-injected metadata should not leak to handlers |
 
 ### Platform-specific gaps
 

--- a/docs/UPSTREAM_SYNC.md
+++ b/docs/UPSTREAM_SYNC.md
@@ -4,13 +4,14 @@ How to keep `chat-sdk-python` in sync with the [Vercel Chat TS SDK](https://gith
 
 ## Version Mapping
 
-Our version number tracks the upstream Vercel Chat minor version:
+Our version embeds the upstream Vercel Chat version: `0.{upstream_major}.{upstream_minor}[.patch]`
 
 | Python version | Upstream version | Meaning |
 |---|---|---|
-| `0.25.0` | `4.25.0` | Synced to upstream 4.25.0 |
-| `0.25.1` | `4.25.0` | Python-only fix on top of 4.25.0 |
-| `0.26.0` | `4.26.0` | Synced to upstream 4.26.0 |
+| `0.4.25` | `4.25.0` | Synced to upstream 4.25.0 |
+| `0.4.25.1` | `4.25.0` | Python-only fix on top of 4.25.0 |
+| `0.4.25a1` | `4.25.0` | Alpha while porting 4.25.0 |
+| `0.4.26` | `4.26.0` | Synced to upstream 4.26.0 |
 
 The `UPSTREAM_PARITY` constant in `chat_sdk/__init__.py` provides programmatic access
 to the upstream version this release is synced to.
@@ -43,7 +44,7 @@ uv run python scripts/verify_test_fidelity.py
 uv run pytest tests/ --tb=short -q
 
 # 6. Update version
-#    - pyproject.toml: version = "0.26.0"
+#    - pyproject.toml: version = "0.4.26"
 #    - README.md: status line
 #    - __init__.py: UPSTREAM_PARITY = "4.26.0"
 #    - CLAUDE.md: version reference
@@ -57,10 +58,19 @@ gh pr create --title "sync: upstream v4.26.0"
 
 - [ ] New types or fields → add to `types.py`
 - [ ] New methods on Thread/Channel → add to `thread.py`/`channel.py`
-- [ ] New adapter features → update the adapter + tests
+- [ ] New adapter features → update the adapter + integration-style tests
 - [ ] New TS tests → run fidelity script, port missing tests
 - [ ] Changed behavior → verify Python matches with regression tests
 - [ ] Review the porting hazards below for each change
+- [ ] Every new `fetch_thread()` behavior → round-trip test with channel APIs
+- [ ] Every new adapter feature → at least one end-to-end test (not just unit/conversion)
+
+### Upstream behavior is one input, not source of truth
+
+If upstream tests are missing coverage for a feature, add Python-only regression
+tests. If upstream tests lock in inconsistent behavior, choose one of:
+- **Preserve parity** and document the inconsistency in the non-parity section below
+- **Intentionally diverge** and document the divergence in the non-parity section
 
 ## How to Diff Upstream Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-sdk"
-version = "0.25.0"
+version = "0.4.25"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/chat_sdk/adapters/github/adapter.py
+++ b/src/chat_sdk/adapters/github/adapter.py
@@ -703,15 +703,15 @@ class GitHubAdapter:
 
             return ThreadInfo(
                 id=thread_id,
-                channel_id=f"{decoded.owner}/{decoded.repo}",
+                channel_id=f"github:{decoded.owner}/{decoded.repo}",
                 channel_name=f"{decoded.repo} #{decoded.pr_number}",
                 is_dm=False,
                 metadata={
                     "owner": decoded.owner,
                     "repo": decoded.repo,
-                    "issueNumber": decoded.pr_number,
-                    "issueTitle": issue.get("title"),
-                    "issueState": issue.get("state"),
+                    "issue_number": decoded.pr_number,
+                    "issue_title": issue.get("title"),
+                    "issue_state": issue.get("state"),
                     "type": "issue",
                 },
             )

--- a/src/chat_sdk/adapters/github/adapter.py
+++ b/src/chat_sdk/adapters/github/adapter.py
@@ -476,24 +476,10 @@ class GitHubAdapter:
                 {"body": body},
             )
 
-        raw: dict[str, Any] = {
-            "type": "review_comment" if decoded.review_comment_id else "issue_comment",
-            "comment": comment,
-            "repository": {
-                "id": 0,
-                "name": decoded.repo,
-                "full_name": f"{decoded.owner}/{decoded.repo}",
-                "owner": {"id": 0, "login": decoded.owner, "type": "User"},
-            },
-            "pr_number": decoded.pr_number,
-        }
-        if not decoded.review_comment_id:
-            raw["thread_type"] = decoded.type or "pr"
-
         return RawMessage(
             id=str(comment["id"]),
             thread_id=thread_id,
-            raw=raw,
+            raw=self._build_raw_message(decoded, comment),
         )
 
     async def edit_message(self, thread_id: str, message_id: str, message: AdapterPostableMessage) -> RawMessage:
@@ -518,24 +504,10 @@ class GitHubAdapter:
                 {"body": body},
             )
 
-        raw: dict[str, Any] = {
-            "type": "review_comment" if decoded.review_comment_id else "issue_comment",
-            "comment": comment,
-            "repository": {
-                "id": 0,
-                "name": decoded.repo,
-                "full_name": f"{decoded.owner}/{decoded.repo}",
-                "owner": {"id": 0, "login": decoded.owner, "type": "User"},
-            },
-            "pr_number": decoded.pr_number,
-        }
-        if not decoded.review_comment_id:
-            raw["thread_type"] = decoded.type or "pr"
-
         return RawMessage(
             id=str(comment["id"]),
             thread_id=thread_id,
-            raw=raw,
+            raw=self._build_raw_message(decoded, comment),
         )
 
     async def stream(
@@ -552,6 +524,24 @@ class GitHubAdapter:
             elif hasattr(chunk, "type") and chunk.type == "markdown_text":
                 text += chunk.text
         return await self.post_message(thread_id, {"markdown": text})
+
+    @staticmethod
+    def _build_raw_message(decoded: Any, comment: dict[str, Any]) -> dict[str, Any]:
+        """Build the raw message dict for post/edit responses."""
+        raw: dict[str, Any] = {
+            "type": "review_comment" if decoded.review_comment_id else "issue_comment",
+            "comment": comment,
+            "repository": {
+                "id": 0,
+                "name": decoded.repo,
+                "full_name": f"{decoded.owner}/{decoded.repo}",
+                "owner": {"id": 0, "login": decoded.owner, "type": "User"},
+            },
+            "pr_number": decoded.pr_number,
+        }
+        if not decoded.review_comment_id:
+            raw["thread_type"] = decoded.type or "pr"
+        return raw
 
     async def delete_message(self, thread_id: str, message_id: str) -> None:
         """Delete a message."""

--- a/src/chat_sdk/adapters/teams/adapter.py
+++ b/src/chat_sdk/adapters/teams/adapter.py
@@ -350,6 +350,20 @@ class TeamsAdapter:
 
         self._chat.process_message(self, thread_id, message, options)
 
+    @staticmethod
+    def _extract_action_values(action_data: dict[str, Any]) -> tuple[str, Any]:
+        """Extract action ID and submitted values from a Teams action payload.
+
+        For plain buttons: ``{"actionId": "btn", "value": "x"}`` → ``("btn", "x")``
+        For ChoiceSet: ``{"actionId": "__auto_submit", "sel": "opt"}`` → ``("__auto_submit", {"sel": "opt"})``
+        """
+        action_id = action_data.get("actionId", "")
+        submitted_values: Any = {k: v for k, v in action_data.items() if k != "actionId"}
+        # Unwrap single "value" key for plain button backward compat
+        if list(submitted_values.keys()) == ["value"]:
+            submitted_values = submitted_values["value"]
+        return action_id, submitted_values
+
     def _handle_message_action(
         self,
         activity: dict[str, Any],
@@ -377,13 +391,7 @@ class TeamsAdapter:
             )
         )
 
-        # Extract action_id; pass remaining keys as value so ChoiceSet
-        # input values are not dropped.
-        action_id = action_value.get("actionId", "")
-        submitted_values = {k: v for k, v in action_value.items() if k != "actionId"}
-        # If there's a single "value" key, unwrap it for simple button clicks
-        if list(submitted_values.keys()) == ["value"]:
-            submitted_values = submitted_values["value"]
+        action_id, submitted_values = self._extract_action_values(action_value)
 
         from_user = activity.get("from", {})
         self._chat.process_action(
@@ -426,10 +434,7 @@ class TeamsAdapter:
             )
         )
 
-        action_id = action_data.get("actionId", "")
-        submitted_values = {k: v for k, v in action_data.items() if k != "actionId"}
-        if list(submitted_values.keys()) == ["value"]:
-            submitted_values = submitted_values["value"]
+        action_id, submitted_values = self._extract_action_values(action_data)
 
         from_user = activity.get("from", {})
         self._chat.process_action(

--- a/src/chat_sdk/adapters/teams/adapter.py
+++ b/src/chat_sdk/adapters/teams/adapter.py
@@ -356,7 +356,14 @@ class TeamsAdapter:
         action_value: dict[str, Any],
         options: WebhookOptions | None = None,
     ) -> None:
-        """Handle Action.Submit button clicks sent as message activities."""
+        """Handle Action.Submit button clicks sent as message activities.
+
+        For plain buttons, ``action_value`` looks like ``{"actionId": "btn_id", "value": "clicked"}``.
+        For ChoiceSet (Select/RadioSelect) submissions, it looks like
+        ``{"actionId": "__auto_submit", "my_select": "option_1"}``.
+        In both cases, we pass the full dict (minus ``actionId``) as ``value``
+        so handlers receive all submitted input values.
+        """
         if not self._chat:
             return
 
@@ -370,11 +377,19 @@ class TeamsAdapter:
             )
         )
 
+        # Extract action_id; pass remaining keys as value so ChoiceSet
+        # input values are not dropped.
+        action_id = action_value.get("actionId", "")
+        submitted_values = {k: v for k, v in action_value.items() if k != "actionId"}
+        # If there's a single "value" key, unwrap it for simple button clicks
+        if list(submitted_values.keys()) == ["value"]:
+            submitted_values = submitted_values["value"]
+
         from_user = activity.get("from", {})
         self._chat.process_action(
             ActionEvent(
-                action_id=action_value.get("actionId", ""),
-                value=action_value.get("value"),
+                action_id=action_id,
+                value=submitted_values,
                 user=Author(
                     user_id=from_user.get("id", "unknown"),
                     user_name=from_user.get("name", "unknown"),
@@ -411,11 +426,16 @@ class TeamsAdapter:
             )
         )
 
+        action_id = action_data.get("actionId", "")
+        submitted_values = {k: v for k, v in action_data.items() if k != "actionId"}
+        if list(submitted_values.keys()) == ["value"]:
+            submitted_values = submitted_values["value"]
+
         from_user = activity.get("from", {})
         self._chat.process_action(
             ActionEvent(
-                action_id=action_data.get("actionId", ""),
-                value=action_data.get("value"),
+                action_id=action_id,
+                value=submitted_values,
                 user=Author(
                     user_id=from_user.get("id", "unknown"),
                     user_name=from_user.get("name", "unknown"),

--- a/src/chat_sdk/adapters/teams/adapter.py
+++ b/src/chat_sdk/adapters/teams/adapter.py
@@ -350,15 +350,21 @@ class TeamsAdapter:
 
         self._chat.process_message(self, thread_id, message, options)
 
+    # Keys injected by the SDK's card renderer or Teams transport — not user input.
+    _ACTION_TRANSPORT_KEYS = frozenset({"actionId", "msteams"})
+
     @staticmethod
     def _extract_action_values(action_data: dict[str, Any]) -> tuple[str, Any]:
         """Extract action ID and submitted values from a Teams action payload.
+
+        Strips transport keys (``actionId``, ``msteams``) that are injected by
+        the SDK's card renderer or Teams infrastructure and are not user input.
 
         For plain buttons: ``{"actionId": "btn", "value": "x"}`` → ``("btn", "x")``
         For ChoiceSet: ``{"actionId": "__auto_submit", "sel": "opt"}`` → ``("__auto_submit", {"sel": "opt"})``
         """
         action_id = action_data.get("actionId", "")
-        submitted_values: Any = {k: v for k, v in action_data.items() if k != "actionId"}
+        submitted_values: Any = {k: v for k, v in action_data.items() if k not in TeamsAdapter._ACTION_TRANSPORT_KEYS}
         # Unwrap single "value" key for plain button backward compat
         if list(submitted_values.keys()) == ["value"]:
             submitted_values = submitted_values["value"]

--- a/src/chat_sdk/channel.py
+++ b/src/chat_sdk/channel.py
@@ -284,6 +284,13 @@ class ChannelImpl:
         """
         if is_postable_object(message):
             await self._handle_postable_object(message)
+            # Cache fallback text in history so the plan appears in channel.messages()
+            if self._message_history is not None:
+                fallback_text = message.get_fallback_text() if hasattr(message, "get_fallback_text") else ""
+                fallback_msg = _to_message(
+                    self._create_sent_message("postable-obj", PostableMarkdown(markdown=fallback_text))
+                )
+                await self._message_history.append(self._id, fallback_msg)
             return message
 
         if _is_async_iterable(message):

--- a/src/chat_sdk/channel.py
+++ b/src/chat_sdk/channel.py
@@ -282,15 +282,10 @@ class ChannelImpl:
         If the message is a PostableObject (e.g. Plan), it is posted via
         native adapter support or fallback text.
         """
+        # Handle PostableObject (e.g. Plan) — returned directly, not cached
+        # in message history (matches upstream TS behavior).
         if is_postable_object(message):
             await self._handle_postable_object(message)
-            # Cache fallback text in history so the plan appears in channel.messages()
-            if self._message_history is not None:
-                fallback_text = message.get_fallback_text() if hasattr(message, "get_fallback_text") else ""
-                fallback_msg = _to_message(
-                    self._create_sent_message("postable-obj", PostableMarkdown(markdown=fallback_text))
-                )
-                await self._message_history.append(self._id, fallback_msg)
             return message
 
         if _is_async_iterable(message):

--- a/src/chat_sdk/channel.py
+++ b/src/chat_sdk/channel.py
@@ -282,10 +282,13 @@ class ChannelImpl:
         If the message is a PostableObject (e.g. Plan), it is posted via
         native adapter support or fallback text.
         """
-        # Handle PostableObject (e.g. Plan) — returned directly, not cached
-        # in message history (matches upstream TS behavior).
+        # Handle PostableObject (e.g. Plan)
         if is_postable_object(message):
-            await self._handle_postable_object(message)
+            raw = await self._handle_postable_object(message)
+            if self._message_history is not None and raw is not None:
+                fallback = message.get_fallback_text() if hasattr(message, "get_fallback_text") else ""
+                sent = self._create_sent_message(raw.id, PostableMarkdown(markdown=fallback), raw.thread_id)
+                await self._message_history.append(self._id, _to_message(sent))
             return message
 
         if _is_async_iterable(message):
@@ -314,7 +317,7 @@ class ChannelImpl:
 
         return sent
 
-    async def _handle_postable_object(self, obj: Any) -> None:
+    async def _handle_postable_object(self, obj: Any) -> Any:
         """Post a PostableObject using native adapter support or fallback."""
         adapter = self.adapter
 
@@ -323,7 +326,7 @@ class ChannelImpl:
                 return await adapter.post_channel_message(thread_id, message)
             return await adapter.post_message(thread_id, message)
 
-        await post_postable_object(obj, adapter, self._id, _post_fn)
+        return await post_postable_object(obj, adapter, self._id, _post_fn)
 
     async def post_ephemeral(
         self,

--- a/src/chat_sdk/plan.py
+++ b/src/chat_sdk/plan.py
@@ -145,8 +145,11 @@ async def post_postable_object(
     thread_id: str,
     post_fn: Any,
     logger: Logger | None = None,
-) -> None:
+) -> Any:
     """Post a PostableObject using the adapter's native support or fallback text.
+
+    Returns the ``RawMessage`` from the adapter so callers can use the
+    real message ID for history caching.
 
     Parameters
     ----------
@@ -176,6 +179,7 @@ async def post_postable_object(
     else:
         raw = await post_fn(thread_id, obj.get_fallback_text())
         obj.on_posted(_make_context(raw))
+    return raw
 
 
 # =============================================================================

--- a/src/chat_sdk/plan.py
+++ b/src/chat_sdk/plan.py
@@ -9,7 +9,6 @@ any PostableObject.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -115,7 +114,8 @@ def _content_to_plain_text(content: PlanContent | None) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, dict) and "markdown" in content:
-        return content["markdown"]
+        md = content["markdown"]
+        return str(md) if md is not None else ""
     if isinstance(content, dict):
         # For ast dicts, return empty -- full rendering not needed for titles
         pass
@@ -125,7 +125,7 @@ def _content_to_plain_text(content: PlanContent | None) -> str:
 def is_postable_object(value: Any) -> bool:
     """Check if a value is a PostableObject (has the required protocol methods)."""
     return (
-        isinstance(value, object)
+        value is not None
         and hasattr(value, "kind")
         and hasattr(value, "get_fallback_text")
         and hasattr(value, "get_post_data")
@@ -419,11 +419,14 @@ class Plan:
 
         # Chain edits: wait for previous edit to finish before starting new one
         if bound.update_chain is not None:
-            with contextlib.suppress(Exception):
+            try:
                 await bound.update_chain
+            except Exception as prev_exc:
+                if bound.logger:
+                    bound.logger.warn("Previous plan edit failed", prev_exc)
 
         try:
-            bound.update_chain = asyncio.ensure_future(_do_edit())
+            bound.update_chain = asyncio.get_running_loop().create_task(_do_edit())
             await bound.update_chain
         except Exception as exc:
             if bound.logger:

--- a/src/chat_sdk/thread.py
+++ b/src/chat_sdk/thread.py
@@ -440,17 +440,10 @@ class ThreadImpl:
         or a PostableObject (e.g. Plan). PostableObjects are returned directly
         after posting so the caller can continue to mutate them.
         """
-        # Handle PostableObject (e.g. Plan)
+        # Handle PostableObject (e.g. Plan) — returned directly, not cached
+        # in message history (matches upstream TS behavior).
         if is_postable_object(message):
             await self._handle_postable_object(message)
-            # Cache the fallback text in message history so the plan appears
-            # in thread.messages() / all_messages() like regular posts.
-            if self._message_history is not None:
-                fallback_text = message.get_fallback_text() if hasattr(message, "get_fallback_text") else ""
-                fallback_msg = _to_message(
-                    self._create_sent_message("postable-obj", PostableMarkdown(markdown=fallback_text), self._id)
-                )
-                await self._message_history.append(self._id, fallback_msg)
             return message
 
         # Handle AsyncIterable (streaming)

--- a/src/chat_sdk/thread.py
+++ b/src/chat_sdk/thread.py
@@ -443,6 +443,14 @@ class ThreadImpl:
         # Handle PostableObject (e.g. Plan)
         if is_postable_object(message):
             await self._handle_postable_object(message)
+            # Cache the fallback text in message history so the plan appears
+            # in thread.messages() / all_messages() like regular posts.
+            if self._message_history is not None:
+                fallback_text = message.get_fallback_text() if hasattr(message, "get_fallback_text") else ""
+                fallback_msg = _to_message(
+                    self._create_sent_message("postable-obj", PostableMarkdown(markdown=fallback_text), self._id)
+                )
+                await self._message_history.append(self._id, fallback_msg)
             return message
 
         # Handle AsyncIterable (streaming)

--- a/src/chat_sdk/thread.py
+++ b/src/chat_sdk/thread.py
@@ -440,10 +440,15 @@ class ThreadImpl:
         or a PostableObject (e.g. Plan). PostableObjects are returned directly
         after posting so the caller can continue to mutate them.
         """
-        # Handle PostableObject (e.g. Plan) — returned directly, not cached
-        # in message history (matches upstream TS behavior).
+        # Handle PostableObject (e.g. Plan)
         if is_postable_object(message):
-            await self._handle_postable_object(message)
+            raw = await self._handle_postable_object(message)
+            # Cache in history with the real message ID (upstream skips this,
+            # but that's a gap — posted messages should appear in history).
+            if self._message_history is not None and raw is not None:
+                fallback = message.get_fallback_text() if hasattr(message, "get_fallback_text") else ""
+                sent = self._create_sent_message(raw.id, PostableMarkdown(markdown=fallback), raw.thread_id)
+                await self._message_history.append(self._id, _to_message(sent))
             return message
 
         # Handle AsyncIterable (streaming)
@@ -459,9 +464,9 @@ class ThreadImpl:
 
         return result
 
-    async def _handle_postable_object(self, obj: Any) -> None:
+    async def _handle_postable_object(self, obj: Any) -> Any:
         """Post a PostableObject using native adapter support or fallback."""
-        await post_postable_object(
+        return await post_postable_object(
             obj,
             self.adapter,
             self._id,

--- a/tests/test_github_extended.py
+++ b/tests/test_github_extended.py
@@ -27,6 +27,7 @@ import pytest
 from chat_sdk.adapters.github.adapter import (
     GitHubAdapter,
 )
+from chat_sdk.adapters.github.types import GitHubThreadId
 from chat_sdk.logger import ConsoleLogger
 from chat_sdk.shared.errors import ValidationError
 
@@ -586,15 +587,15 @@ class TestFetchThread:
         assert "/pulls/" not in call[0][1]
 
         assert info.id == "github:acme/app:issue:10"
-        assert info.channel_id == "acme/app"
+        assert info.channel_id == "github:acme/app"
         assert info.channel_name == "app #10"
         assert info.is_dm is False
         assert info.metadata == {
             "owner": "acme",
             "repo": "app",
-            "issueNumber": 10,
-            "issueTitle": "Bug report",
-            "issueState": "open",
+            "issue_number": 10,
+            "issue_title": "Bug report",
+            "issue_state": "open",
             "type": "issue",
         }
 
@@ -786,3 +787,22 @@ class TestStream:
         # The post should have been called with the accumulated text
         call_args = adapter._github_api_request.call_args
         assert call_args[0][2]["body"] == "Hello world"
+
+
+class TestIssueThreadChannelRoundTrip:
+    """fetch_thread().channel_id should work with channel APIs."""
+
+    async def test_issue_thread_channel_id_round_trips(self):
+        """channel_id from fetch_thread feeds into channel_id_from_thread_id."""
+        adapter = _make_adapter()
+        adapter._github_api_request = AsyncMock(return_value={"title": "Bug report", "state": "open", "number": 10})
+
+        thread_id = adapter.encode_thread_id(GitHubThreadId(owner="acme", repo="app", pr_number=10, type="issue"))
+        info = await adapter.fetch_thread(thread_id)
+
+        # channel_id should have github: prefix
+        assert info.channel_id.startswith("github:")
+
+        # channel_id should work with channel_id_from_thread_id
+        derived_channel = adapter.channel_id_from_thread_id(thread_id)
+        assert info.channel_id == derived_channel

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -499,3 +499,77 @@ class TestEdgeCases:
         assert task is not None
         # Check internal model has details
         assert plan._model.tasks[-1].details == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Error handling in _enqueue_edit
+# ---------------------------------------------------------------------------
+
+
+class _FailingEditAdapter(MockAdapter):
+    """MockAdapter whose edit_message raises on demand."""
+
+    def __init__(self) -> None:
+        super().__init__("failing")
+        self.fail_edit = False
+
+    async def edit_message(self, thread_id: str, message_id: str, message: Any) -> RawMessage:
+        if self.fail_edit:
+            raise RuntimeError("simulated edit failure")
+        return await super().edit_message(thread_id, message_id, message)
+
+
+class _SpyLogger:
+    """Minimal logger that records warn calls."""
+
+    def __init__(self) -> None:
+        self.warnings: list[tuple[str, Any]] = []
+
+    def child(self, prefix: str) -> _SpyLogger:
+        return self
+
+    def debug(self, message: str, *args: Any) -> None:
+        pass
+
+    def info(self, message: str, *args: Any) -> None:
+        pass
+
+    def warn(self, message: str, *args: Any) -> None:
+        self.warnings.append((message, args))
+
+    def error(self, message: str, *args: Any) -> None:
+        pass
+
+
+class TestEditErrorPath:
+    @pytest.mark.asyncio
+    async def test_edit_failure_is_logged_and_plan_continues(self) -> None:
+        """When adapter.edit_message raises, the error is logged and
+        the next mutation still fires successfully."""
+        adapter = _FailingEditAdapter()
+        logger = _SpyLogger()
+        thread = _make_thread(adapter=adapter)
+        plan = Plan(StartPlanOptions(initial_message="Step 1"))
+        await thread.post(plan)
+
+        # Inject the spy logger into the bound state
+        assert plan._bound is not None
+        plan._bound.logger = logger
+
+        # First mutation: edit will fail
+        adapter.fail_edit = True
+        await plan.add_task(AddTaskOptions(title="Step 2"))
+
+        # The error should have been logged
+        assert any("Failed to edit plan" in w[0] for w in logger.warnings)
+
+        # Second mutation: edit succeeds -- plan is still usable
+        adapter.fail_edit = False
+        logger.warnings.clear()
+        task = await plan.add_task(AddTaskOptions(title="Step 3"))
+        assert task is not None
+        assert task.title == "Step 3"
+        assert len(plan.tasks) == 3
+
+        # The previous-chain failure should also be logged
+        assert any("Previous plan edit failed" in w[0] for w in logger.warnings)

--- a/tests/test_teams_cards.py
+++ b/tests/test_teams_cards.py
@@ -467,3 +467,38 @@ class TestTeamsCardInputEndToEnd:
         assert action_event.action_id == "approve_btn"
         # Single "value" key gets unwrapped for backward compat
         assert action_event.value == "approved"
+
+    async def test_modal_button_strips_msteams_transport_key(self):
+        """Buttons with action_type=modal include msteams metadata that must be stripped."""
+        from unittest.mock import MagicMock
+
+        from chat_sdk.adapters.teams.adapter import TeamsAdapter
+        from chat_sdk.adapters.teams.types import TeamsAdapterConfig
+
+        adapter = TeamsAdapter(
+            TeamsAdapterConfig(
+                app_id="test-app",
+                app_password="test-pass",
+            )
+        )
+        mock_chat = MagicMock()
+        adapter._chat = mock_chat
+
+        # Simulate payload from a modal button (has msteams transport key)
+        activity = {
+            "type": "message",
+            "from": {"id": "user-1", "name": "Test User"},
+            "conversation": {"id": "conv-1"},
+            "serviceUrl": "https://smba.trafficmanager.net/teams/",
+            "value": {
+                "actionId": "open_dialog",
+                "value": "clicked",
+                "msteams": {"type": "task/fetch"},
+            },
+        }
+        await adapter._handle_message_activity(activity)
+
+        action_event = mock_chat.process_action.call_args[0][0]
+        assert action_event.action_id == "open_dialog"
+        # msteams key should be stripped — only user value remains
+        assert action_event.value == "clicked"

--- a/tests/test_teams_cards.py
+++ b/tests/test_teams_cards.py
@@ -361,3 +361,109 @@ class TestCardToFallbackText:
         card = Card(title="Simple Card")
         text = card_to_fallback_text(card)
         assert text == "**Simple Card**"
+
+
+class TestTeamsCardInputEndToEnd:
+    """End-to-end: render card with Select -> submit Action.Submit -> verify process_action values."""
+
+    async def test_select_submit_round_trip(self):
+        """Card with Select renders ChoiceSet; submitted values reach process_action."""
+        from unittest.mock import MagicMock
+
+        from chat_sdk.adapters.teams.adapter import TeamsAdapter
+        from chat_sdk.adapters.teams.cards import AUTO_SUBMIT_ACTION_ID
+        from chat_sdk.adapters.teams.types import TeamsAdapterConfig
+
+        adapter = TeamsAdapter(
+            TeamsAdapterConfig(
+                app_id="test-app",
+                app_password="test-pass",
+            )
+        )
+        mock_chat = MagicMock()
+        adapter._chat = mock_chat
+
+        # 1. Render a card with a Select
+        card_element = Card(
+            title="Pick a color",
+            children=[
+                Actions(
+                    [
+                        Select(
+                            id="color_select",
+                            label="Color",
+                            options=[
+                                SelectOption(label="Red", value="red"),
+                                SelectOption(label="Blue", value="blue"),
+                            ],
+                        )
+                    ]
+                )
+            ],
+        )
+        adaptive = card_to_adaptive_card(card_element)
+
+        # Verify ChoiceSet was rendered
+        body = adaptive.get("body", [])
+        choice_set = next((b for b in body if b.get("type") == "Input.ChoiceSet"), None)
+        assert choice_set is not None
+        assert choice_set["id"] == "color_select"
+        assert len(choice_set["choices"]) == 2
+
+        # Verify auto-submit action exists
+        actions = adaptive.get("actions", [])
+        submit_action = next((a for a in actions if a.get("type") == "Action.Submit"), None)
+        assert submit_action is not None
+
+        # 2. Simulate Teams sending Action.Submit with the selected value
+        activity = {
+            "type": "message",
+            "from": {"id": "user-1", "name": "Test User"},
+            "conversation": {"id": "conv-1"},
+            "serviceUrl": "https://smba.trafficmanager.net/teams/",
+            "value": {
+                "actionId": AUTO_SUBMIT_ACTION_ID,
+                "color_select": "blue",
+            },
+        }
+        await adapter._handle_message_activity(activity)
+
+        # 3. Verify process_action received the selected values
+        mock_chat.process_action.assert_called_once()
+        action_event = mock_chat.process_action.call_args[0][0]
+        assert action_event.action_id == AUTO_SUBMIT_ACTION_ID
+        assert action_event.value == {"color_select": "blue"}
+        assert action_event.user.user_id == "user-1"
+
+    async def test_button_click_still_works(self):
+        """Plain button Action.Submit still passes value correctly."""
+        from unittest.mock import MagicMock
+
+        from chat_sdk.adapters.teams.adapter import TeamsAdapter
+        from chat_sdk.adapters.teams.types import TeamsAdapterConfig
+
+        adapter = TeamsAdapter(
+            TeamsAdapterConfig(
+                app_id="test-app",
+                app_password="test-pass",
+            )
+        )
+        mock_chat = MagicMock()
+        adapter._chat = mock_chat
+
+        activity = {
+            "type": "message",
+            "from": {"id": "user-1", "name": "Test User"},
+            "conversation": {"id": "conv-1"},
+            "serviceUrl": "https://smba.trafficmanager.net/teams/",
+            "value": {
+                "actionId": "approve_btn",
+                "value": "approved",
+            },
+        }
+        await adapter._handle_message_activity(activity)
+
+        action_event = mock_chat.process_action.call_args[0][0]
+        assert action_event.action_id == "approve_btn"
+        # Single "value" key gets unwrapped for backward compat
+        assert action_event.value == "approved"


### PR DESCRIPTION
## Summary

Syncs to Vercel Chat v4.25.0 with review fixes, integration tests, and new version scheme.

### Version scheme
`0.{upstream_major}.{upstream_minor}[.patch]` — our `0.4.25` = upstream `4.25.0`.

### Changes from upstream 4.25.0
- Plan/PostableObject blocks
- Streaming table `wrap_tables_for_append` option  
- Teams Select/RadioSelect card rendering
- GitHub issue comment threads
- Slack OAuth redirect fix

### Review fixes (not in upstream)
- Teams Action.Submit now passes all ChoiceSet input values (was dropping them)
- End-to-end Teams card input test (render → submit → verify)
- GitHub fetch_thread issue threads return correct channel_id with prefix
- GitHub issue metadata uses snake_case (not camelCase)
- Plan: create_task not ensure_future, logged edit errors, type-safe content
- GitHub channel_id round-trip test

### Process
- UPSTREAM_SYNC.md: upstream behavior is input not source of truth
- Every adapter feature needs integration test, every fetch_thread needs round-trip test

## Test plan
- [x] 3420 passed, 0 warnings, 0 lint errors
- [x] 535/535 fidelity
- [x] CI green on 3.10-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)