### PR TITLE
feat(thread): port getParticipants + close 8 fidelity gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Unreleased
 
+Parity catch-up with upstream `4.26.0`. No upstream version change.
+
 ### New public APIs
 
+- **`Thread.get_participants()`**: returns unique non-bot, non-self authors
+  who've posted in the thread. Seeds from `current_message.author` (if
+  eligible), then iterates `all_messages()` and dedupes by `user_id`.
+  Mirrors upstream TS `Thread.getParticipants()`. Issue #54.
 - **`IoRedisStateAdapter`**: `RedisStateAdapter` subclass defaulting to the
   `ioredis_` lock-token prefix used by upstream Vercel Chat's `ioredis`-backed
   state. Enables cross-runtime Redis sharing between TS and Python chat-sdk
@@ -33,6 +39,12 @@
   not yet supported by the Teams SDK adapter. Use appPassword (client secret)
   or federated (workload identity) authentication instead."`). Not a functional
   implementation; upstream does not implement cert auth either.
+
+### Test fidelity
+
+- Ported the 4 `[getParticipants]` tests from `thread.test.ts` and the 4
+  `[thread]` factory tests from `chat.test.ts` (existing-behavior coverage
+  for `Chat.thread(id)`). Closes 8 fidelity gaps.
 
 ### Test hygiene
 

--- a/src/chat_sdk/thread.py
+++ b/src/chat_sdk/thread.py
@@ -430,6 +430,30 @@ class ThreadImpl:
             for msg in cached:
                 yield msg
 
+    async def get_participants(self) -> list[Author]:
+        """Return unique non-bot, non-self authors who've posted in the thread.
+
+        Mirrors ``getParticipants`` from the upstream TS SDK: seeds the
+        result with ``_current_message.author`` (if present and eligible),
+        then scans ``all_messages()`` oldest-first, skipping ``is_me`` and
+        ``is_bot`` authors and deduping by ``user_id``.
+        """
+        seen: dict[str, Author] = {}
+
+        if (
+            self._current_message is not None
+            and not self._current_message.author.is_me
+            and not self._current_message.author.is_bot
+        ):
+            seen[self._current_message.author.user_id] = self._current_message.author
+
+        async for msg in self.all_messages():
+            if msg.author.is_me or msg.author.is_bot or msg.author.user_id in seen:
+                continue
+            seen[msg.author.user_id] = msg.author
+
+        return list(seen.values())
+
     # -- Subscriptions -------------------------------------------------------
 
     async def is_subscribed(self) -> bool:

--- a/src/chat_sdk/types.py
+++ b/src/chat_sdk/types.py
@@ -1519,6 +1519,10 @@ class Thread(Postable, Protocol):
         """Refresh ``recent_messages`` from the API."""
         ...
 
+    async def get_participants(self) -> list[Author]:
+        """Return unique non-bot, non-self authors who've posted in the thread."""
+        ...
+
     def create_sent_message_from_message(self, message: Message) -> SentMessage:
         """Wrap a Message as a SentMessage with edit/delete capabilities."""
         ...

--- a/tests/test_chat_faithful.py
+++ b/tests/test_chat_faithful.py
@@ -1283,6 +1283,45 @@ class TestOpenDM:
 
 
 # ============================================================================
+# thread() factory
+# ============================================================================
+
+
+class TestThreadFactory:
+    """describe("thread") — chat.thread(id) factory for building a Thread handle."""
+
+    # TS: "should return a Thread handle for a valid thread ID"
+    async def test_should_return_a_thread_handle_for_a_valid_thread_id(self):
+        chat, adapter, state = await _init_chat()
+        thread = chat.thread("slack:C123:1234.5678")
+        assert thread is not None
+        assert thread.id == "slack:C123:1234.5678"
+
+    # TS: "should allow posting to a thread handle"
+    async def test_should_allow_posting_to_a_thread_handle(self):
+        chat, adapter, state = await _init_chat()
+        thread = chat.thread("slack:C123:1234.5678")
+        await thread.post("Hello from outside a webhook!")
+
+        assert any(
+            tid == "slack:C123:1234.5678" and content == "Hello from outside a webhook!"
+            for tid, content in adapter._post_calls
+        )
+
+    # TS: "should throw for an invalid thread ID"
+    async def test_should_throw_for_an_invalid_thread_id(self):
+        chat, adapter, state = await _init_chat()
+        with pytest.raises(ChatError, match="Invalid thread ID"):
+            chat.thread("")
+
+    # TS: "should throw for an unknown adapter prefix"
+    async def test_should_throw_for_an_unknown_adapter_prefix(self):
+        chat, adapter, state = await _init_chat()
+        with pytest.raises(ChatError, match=r'Adapter "unknown" not found'):
+            chat.thread("unknown:C123:1234.5678")
+
+
+# ============================================================================
 # 14. isDM (tests 55-57)
 # ============================================================================
 

--- a/tests/test_thread_faithful.py
+++ b/tests/test_thread_faithful.py
@@ -2614,6 +2614,33 @@ class TestGetParticipants:
         assert len(participants) == 1
         assert participants[0].user_id == "U1"
 
+    # Python-only: isolates the is_me=True, is_bot=False exclusion path
+    # (addresses PR #64 bot-review nit — prior test mixes is_bot and is_me).
+    @pytest.mark.asyncio
+    async def test_should_exclude_self_messages_even_when_not_bot(self):
+        adapter = create_mock_adapter()
+        state = create_mock_state()
+
+        self_msg = create_test_message(
+            "1",
+            "my msg",
+            author=Author(user_id="U_SELF", user_name="me", full_name="Me", is_bot=False, is_me=True),
+        )
+        other_msg = create_test_message(
+            "2",
+            "hi",
+            author=Author(user_id="U1", user_name="alice", full_name="Alice", is_bot=False, is_me=False),
+        )
+
+        adapter.fetch_messages = AsyncMock(  # type: ignore[assignment]
+            return_value=FetchResult(messages=[self_msg, other_msg], next_cursor=None)
+        )
+
+        thread = _make_thread(adapter, state)
+        participants = await thread.get_participants()
+
+        assert [p.user_id for p in participants] == ["U1"]
+
     # it("should return empty array for thread with only bot messages")
     @pytest.mark.asyncio
     async def test_should_return_empty_array_for_thread_with_only_bot_messages(self):

--- a/tests/test_thread_faithful.py
+++ b/tests/test_thread_faithful.py
@@ -2540,6 +2540,124 @@ class TestDeriveChannelId:
         assert channel_id == "gchat:spaces/ABC123"
 
 
+# ===========================================================================
+# getParticipants
+# ===========================================================================
+
+
+class TestGetParticipants:
+    """describe("getParticipants")"""
+
+    # it("should return unique non-bot authors from messages")
+    @pytest.mark.asyncio
+    async def test_should_return_unique_nonbot_authors_from_messages(self):
+        adapter = create_mock_adapter()
+        state = create_mock_state()
+
+        msg1 = create_test_message(
+            "1",
+            "Hello",
+            author=Author(user_id="U1", user_name="alice", full_name="Alice", is_bot=False, is_me=False),
+        )
+        msg2 = create_test_message(
+            "2",
+            "Hi",
+            author=Author(user_id="U2", user_name="bob", full_name="Bob", is_bot=False, is_me=False),
+        )
+        msg3 = create_test_message(
+            "3",
+            "Hello again",
+            author=Author(user_id="U1", user_name="alice", full_name="Alice", is_bot=False, is_me=False),
+        )
+
+        adapter.fetch_messages = AsyncMock(  # type: ignore[assignment]
+            return_value=FetchResult(messages=[msg1, msg2, msg3], next_cursor=None)
+        )
+
+        thread = _make_thread(adapter, state)
+        participants = await thread.get_participants()
+
+        assert len(participants) == 2
+        user_ids = [p.user_id for p in participants]
+        assert "U1" in user_ids
+        assert "U2" in user_ids
+
+    # it("should exclude bot messages")
+    @pytest.mark.asyncio
+    async def test_should_exclude_bot_messages(self):
+        adapter = create_mock_adapter()
+        state = create_mock_state()
+
+        human_msg = create_test_message(
+            "1",
+            "Hello",
+            author=Author(user_id="U1", user_name="alice", full_name="Alice", is_bot=False, is_me=False),
+        )
+        self_bot_msg = create_test_message(
+            "2",
+            "Hi there!",
+            author=Author(user_id="B1", user_name="bot", full_name="Bot", is_bot=True, is_me=True),
+        )
+        third_party_bot_msg = create_test_message(
+            "3",
+            "Notification",
+            author=Author(user_id="B2", user_name="jira-bot", full_name="Jira Bot", is_bot=True, is_me=False),
+        )
+
+        adapter.fetch_messages = AsyncMock(  # type: ignore[assignment]
+            return_value=FetchResult(messages=[human_msg, self_bot_msg, third_party_bot_msg], next_cursor=None)
+        )
+
+        thread = _make_thread(adapter, state)
+        participants = await thread.get_participants()
+
+        assert len(participants) == 1
+        assert participants[0].user_id == "U1"
+
+    # it("should return empty array for thread with only bot messages")
+    @pytest.mark.asyncio
+    async def test_should_return_empty_array_for_thread_with_only_bot_messages(self):
+        adapter = create_mock_adapter()
+        state = create_mock_state()
+
+        bot_msg = create_test_message(
+            "1",
+            "Bot message",
+            author=Author(user_id="B1", user_name="bot", full_name="Bot", is_bot=True, is_me=True),
+        )
+
+        adapter.fetch_messages = AsyncMock(  # type: ignore[assignment]
+            return_value=FetchResult(messages=[bot_msg], next_cursor=None)
+        )
+
+        thread = _make_thread(adapter, state)
+        participants = await thread.get_participants()
+
+        assert len(participants) == 0
+
+    # it("should include currentMessage author")
+    @pytest.mark.asyncio
+    async def test_should_include_currentmessage_author(self):
+        adapter = create_mock_adapter()
+        state = create_mock_state()
+
+        current_msg = create_test_message(
+            "1",
+            "Hey bot",
+            author=Author(user_id="U1", user_name="alice", full_name="Alice", is_bot=False, is_me=False),
+        )
+
+        adapter.fetch_messages = AsyncMock(  # type: ignore[assignment]
+            return_value=FetchResult(messages=[], next_cursor=None)
+        )
+
+        thread = _make_thread(adapter, state, current_message=current_msg)
+        participants = await thread.get_participants()
+
+        assert len(participants) == 1
+        assert participants[0].user_id == "U1"
+
+
 class TestMissingAbsorbers:
     """Fidelity-check absorbers for TS test names that have no Python equivalent."""
 


### PR DESCRIPTION
## Summary

- Ports `Thread.get_participants()` from upstream TS (`vercel-chat/packages/chat/src/thread.ts:359`). Returns unique non-bot, non-self authors who've posted in the thread; seeds from `current_message.author` when eligible, iterates `all_messages()` oldest-first, dedupes on `user_id`. Added to the `Thread` Protocol.
- Closes 8 fidelity gaps: 4 `[getParticipants]` tests from `thread.test.ts` + 4 `[thread]` factory tests from `chat.test.ts` (existing-behavior coverage for `Chat.thread(id)` that had no Python equivalent).

Refs #54. First of several upstream-parity PRs targeting bundled release `0.4.26.2`. CHANGELOG entry lands under `## Unreleased`.

## Fidelity impact

`verify_test_fidelity.py`: 40 missing → **32 missing** (closed exactly the 8 covered here). Remaining gaps trace to #50 (Options Load), #52 (rehydrate), and StreamingPlan feature work (#53).

## Test plan

- [x] `uv run pytest tests/test_thread_faithful.py::TestGetParticipants -q` — 4 passed
- [x] `uv run pytest tests/test_chat_faithful.py::TestThreadFactory -q` — 4 passed
- [x] `uv run ruff check src/ tests/ scripts/` — clean
- [x] `uv run ruff format --check src/ tests/ scripts/` — clean
- [x] `uv run python scripts/audit_test_quality.py` — 0 hard failures
- [x] `uv run python scripts/verify_test_fidelity.py` — 8 gaps closed
- [x] `uv run pytest tests/ --tb=short -q` — 3553 passed, 2 skipped, 0 failed

## Notes

- Issue #54's body sketched a simplified implementation that omitted `is_me` filtering and used `messages()` (newest-first). I ported the real upstream: filters both `is_me` and `is_bot`, and uses `all_messages()` (oldest-first) to match the map-seeding order.
- No version bump — accumulating under `## Unreleased` per the `0.4.26.1`-style bundled-release pattern. A separate release PR will flip to `## 0.4.26.2 (date)` + bump `pyproject.toml` once 2–3 items land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `get_participants()` method to threads for retrieving unique message participants, automatically excluding bots and the current user.

* **Tests**
  * Added test coverage for thread operations, including creation, validation, and error handling.
  * Added tests for participant retrieval to verify filtering and deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->