### PR TITLE
feat(teams): port TeamsAuthCertificate config shape (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@
   (default `"redis"`). Parameterizes the lock-token prefix for observability
   and interop.
 
+### Upstream parity
+
+- **Teams: `TeamsAuthCertificate` config shape** (Issue #58). Ports the
+  upstream `TeamsAuthCertificate` interface (`adapter-teams/src/types.ts:3-10`)
+  as a Python dataclass with `certificate_private_key`, `certificate_thumbprint`,
+  and `x5c` fields. `TeamsAdapterConfig(certificate=...)` is accepted and
+  re-exported from `chat_sdk.adapters.teams` so consumers can code against the
+  shape ahead of MS Teams SDK support. Passing a non-`None` value still throws
+  at adapter startup — the error message is now verbatim with
+  `adapter-teams/src/config.ts:13-18` (`"Certificate-based authentication is
+  not yet supported by the Teams SDK adapter. Use appPassword (client secret)
+  or federated (workload identity) authentication instead."`). Not a functional
+  implementation; upstream does not implement cert auth either.
+
 ### Test hygiene
 
 - Sweep remaining `time.sleep` → `await asyncio.sleep` in async tests

--- a/src/chat_sdk/adapters/teams/__init__.py
+++ b/src/chat_sdk/adapters/teams/__init__.py
@@ -1,5 +1,14 @@
 """Teams adapter for chat-sdk."""
 
 from chat_sdk.adapters.teams.adapter import TeamsAdapter, create_teams_adapter
+from chat_sdk.adapters.teams.types import (
+    TeamsAdapterConfig,
+    TeamsAuthCertificate,
+)
 
-__all__ = ["TeamsAdapter", "create_teams_adapter"]
+__all__ = [
+    "TeamsAdapter",
+    "TeamsAdapterConfig",
+    "TeamsAuthCertificate",
+    "create_teams_adapter",
+]

--- a/src/chat_sdk/adapters/teams/adapter.py
+++ b/src/chat_sdk/adapters/teams/adapter.py
@@ -162,11 +162,13 @@ class TeamsAdapter:
         self._app_password = config.app_password or os.environ.get("TEAMS_APP_PASSWORD", "")
         self._app_tenant_id = config.app_tenant_id or os.environ.get("TEAMS_APP_TENANT_ID", "")
 
-        if config.certificate:
+        if config.certificate is not None:
+            # Exact parity with upstream adapter-teams/src/config.ts:13-18.
+            # ``appPassword`` is referenced in camelCase to match upstream text.
             raise ValidationError(
                 "teams",
-                "Certificate-based authentication is not yet supported. "
-                "Use app_password (client secret) or federated (workload identity) authentication instead.",
+                "Certificate-based authentication is not yet supported by the Teams SDK adapter. "
+                "Use appPassword (client secret) or federated (workload identity) authentication instead.",
             )
 
         if not self._app_id:

--- a/src/chat_sdk/adapters/teams/types.py
+++ b/src/chat_sdk/adapters/teams/types.py
@@ -16,15 +16,24 @@ from chat_sdk.logger import Logger
 # =============================================================================
 
 
-class TeamsAuthCertificate(TypedDict, total=False):
-    """Certificate-based authentication config (not yet supported)."""
+@dataclass
+class TeamsAuthCertificate:
+    """Certificate-based authentication config.
+
+    .. deprecated::
+        Certificate auth is not yet supported by the Teams SDK. Setting
+        ``certificate`` on :class:`TeamsAdapterConfig` raises at adapter
+        startup. Ported for shape parity with upstream
+        ``adapter-teams/src/types.ts`` so consumers can code against the
+        config shape ahead of MS Teams SDK support.
+    """
 
     # PEM-encoded certificate private key
     certificate_private_key: str
     # Hex-encoded certificate thumbprint (optional when x5c is provided)
-    certificate_thumbprint: str
+    certificate_thumbprint: str | None = None
     # Public certificate for subject-name validation (optional)
-    x5c: str
+    x5c: str | None = None
 
 
 class TeamsAuthFederated(TypedDict, total=False):
@@ -53,7 +62,9 @@ class TeamsAdapterConfig:
     app_tenant_id: str | None = None
     # Microsoft App Type.
     app_type: str | None = None  # "MultiTenant" | "SingleTenant"
-    # Certificate auth (not yet supported by the Teams SDK).
+    # Deprecated: certificate auth is not yet supported by the Teams SDK.
+    # Passing a non-None value raises at adapter startup — kept for shape
+    # parity with upstream adapter-teams/src/types.ts.
     certificate: TeamsAuthCertificate | None = None
     # Federated (workload identity) authentication.
     federated: TeamsAuthFederated | None = None

--- a/tests/test_teams_coverage.py
+++ b/tests/test_teams_coverage.py
@@ -29,7 +29,6 @@ from chat_sdk.adapters.teams.adapter import (
 )
 from chat_sdk.adapters.teams.types import (
     TeamsAdapterConfig,
-    TeamsAuthCertificate,
     TeamsThreadId,
 )
 from chat_sdk.shared.errors import (
@@ -1480,26 +1479,6 @@ class TestFetchMessagesAdvanced:
                 FetchOptions(direction="forward", cursor="2024-05-01T00:00:00Z"),
             )
             assert len(result.messages) >= 0
-
-
-# ---------------------------------------------------------------------------
-# Certificate config raises
-# ---------------------------------------------------------------------------
-
-
-class TestCertificateConfig:
-    def test_certificate_raises_validation_error(self):
-        with pytest.raises(ValidationError, match="Certificate"):
-            TeamsAdapter(
-                TeamsAdapterConfig(
-                    app_id="test",
-                    app_password="test",
-                    certificate=TeamsAuthCertificate(
-                        certificate_private_key="key",
-                        certificate_thumbprint="abc",
-                    ),
-                )
-            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_teams_coverage.py
+++ b/tests/test_teams_coverage.py
@@ -27,7 +27,11 @@ from chat_sdk.adapters.teams.adapter import (
     TeamsAdapter,
     _validate_service_url,
 )
-from chat_sdk.adapters.teams.types import TeamsAdapterConfig, TeamsThreadId
+from chat_sdk.adapters.teams.types import (
+    TeamsAdapterConfig,
+    TeamsAuthCertificate,
+    TeamsThreadId,
+)
 from chat_sdk.shared.errors import (
     AuthenticationError,
     NetworkError,
@@ -1490,7 +1494,10 @@ class TestCertificateConfig:
                 TeamsAdapterConfig(
                     app_id="test",
                     app_password="test",
-                    certificate={"thumbprint": "abc", "private_key": "key"},
+                    certificate=TeamsAuthCertificate(
+                        certificate_private_key="key",
+                        certificate_thumbprint="abc",
+                    ),
                 )
             )
 

--- a/tests/test_teams_extended.py
+++ b/tests/test_teams_extended.py
@@ -28,7 +28,11 @@ from chat_sdk.adapters.teams.adapter import (
     TeamsAdapter,
     _handle_teams_error,
 )
-from chat_sdk.adapters.teams.types import TeamsAdapterConfig, TeamsThreadId
+from chat_sdk.adapters.teams.types import (
+    TeamsAdapterConfig,
+    TeamsAuthCertificate,
+    TeamsThreadId,
+)
 from chat_sdk.shared.errors import (
     AdapterPermissionError,
     AdapterRateLimitError,
@@ -542,9 +546,44 @@ class TestCertificateAuth:
                 TeamsAdapterConfig(
                     app_id="app",
                     app_password="pass",
-                    certificate={"certificate_private_key": "key", "certificate_thumbprint": "thumb"},
+                    certificate=TeamsAuthCertificate(
+                        certificate_private_key="key",
+                        certificate_thumbprint="thumb",
+                    ),
                 )
             )
+
+    def test_raises_with_exact_upstream_message(self):
+        """Startup throw message matches upstream adapter-teams/src/config.ts:13-18 verbatim.
+
+        Upstream references ``appPassword`` (camelCase TS field name); we preserve
+        that in the error text so consumers tailing upstream logs see identical
+        output. Protects against well-meaning rewording to ``app_password``.
+        """
+        expected = (
+            "Certificate-based authentication is not yet supported by the Teams SDK adapter. "
+            "Use appPassword (client secret) or federated (workload identity) authentication instead."
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            TeamsAdapter(
+                TeamsAdapterConfig(
+                    certificate=TeamsAuthCertificate(certificate_private_key="key"),
+                )
+            )
+        assert expected in str(exc_info.value)
+
+    def test_minimal_certificate_only_requires_private_key(self):
+        """``certificate_thumbprint`` and ``x5c`` are optional per upstream types.ts:7-9.
+
+        A ``TeamsAuthCertificate`` constructed with only ``certificate_private_key``
+        must still trigger the startup throw (i.e. the adapter checks presence, not
+        shape).
+        """
+        cert = TeamsAuthCertificate(certificate_private_key="pem-key")
+        assert cert.certificate_thumbprint is None
+        assert cert.x5c is None
+        with pytest.raises(ValidationError, match="Certificate-based"):
+            TeamsAdapter(TeamsAdapterConfig(certificate=cert))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Ports `TeamsAuthCertificate` interface from upstream (`adapter-teams/src/types.ts:3-10`)
- Adds `certificate` field to `TeamsAdapterConfig` with `@deprecated`-equivalent docstring
- Throws at startup with the exact upstream error message if `certificate` is set — matches `adapter-teams/src/config.ts:13-18`
- NOT a functional implementation: upstream doesn't implement cert auth either. Pure config-shape parity so consumers can code against the shape ahead of MS Teams SDK support.

Refs #58. Queued under `## Unreleased` for bundled `0.4.26.2`.

## Test plan
- [x] Startup throw test (faithful to upstream behavior)
- [x] Full validation block from CLAUDE.md passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed certificate-based auth configuration and related types for the Teams adapter (providing a certificate still triggers a startup error).

* **Documentation**
  * Marked certificate authentication as deprecated/unsupported and clarified startup behavior.
  * Updated validation/error text for clearer messaging when certificate auth is attempted.

* **Tests**
  * Updated tests to use the new config shape and assert the revised validation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->