### PR TITLE
ci(fidelity): ratchet-down baseline + wire into lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,17 +59,16 @@ jobs:
 
       - name: Clone upstream vercel/chat at pinned parity tag
         id: clone_upstream
-        continue-on-error: true
         run: |
           git clone --depth 1 --branch chat@4.26.0 \
             https://github.com/vercel/chat.git /tmp/vercel-chat
 
-      - name: Test fidelity check (baseline-enforced)
+      - name: Test fidelity check (strict — zero missing)
         id: fidelity
         continue-on-error: true
         env:
           TS_ROOT: /tmp/vercel-chat
-        run: uv run python scripts/verify_test_fidelity.py
+        run: uv run python scripts/verify_test_fidelity.py --strict
 
       - name: Pyrefly type check
         id: pyrefly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,20 @@ jobs:
         continue-on-error: true
         run: uv run python scripts/audit_test_quality.py
 
+      - name: Clone upstream vercel/chat at pinned parity tag
+        id: clone_upstream
+        continue-on-error: true
+        run: |
+          git clone --depth 1 --branch chat@4.26.0 \
+            https://github.com/vercel/chat.git /tmp/vercel-chat
+
+      - name: Test fidelity check (baseline-enforced)
+        id: fidelity
+        continue-on-error: true
+        env:
+          TS_ROOT: /tmp/vercel-chat
+        run: uv run python scripts/verify_test_fidelity.py
+
       - name: Pyrefly type check
         id: pyrefly
         continue-on-error: true
@@ -75,6 +89,7 @@ jobs:
           echo "| Ruff check | ${{ steps.ruff_check.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Ruff format | ${{ steps.ruff_format.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Test audit | ${{ steps.audit.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Test fidelity | ${{ steps.fidelity.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Pyrefly | ${{ steps.pyrefly.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.pyrefly.outcome }}" = "success" ]; then
@@ -89,10 +104,11 @@ jobs:
           RUFF_CHECK: ${{ steps.ruff_check.outcome }}
           RUFF_FORMAT: ${{ steps.ruff_format.outcome }}
           AUDIT: ${{ steps.audit.outcome }}
+          FIDELITY: ${{ steps.fidelity.outcome }}
           PYREFLY: ${{ steps.pyrefly.outcome }}
         run: |
           failures=0
-          for var in RUFF_CHECK RUFF_FORMAT AUDIT PYREFLY; do
+          for var in RUFF_CHECK RUFF_FORMAT AUDIT FIDELITY PYREFLY; do
             outcome="${!var}"
             if [ "$outcome" != "success" ]; then
               echo "$var failed (outcome: $outcome)"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,7 @@ jobs:
           git clone --depth 1 --branch chat@4.26.0 \
             https://github.com/vercel/chat.git /tmp/vercel-chat
 
-      - name: Test fidelity check (strict — zero missing)
+      - name: Test fidelity check (strict — zero missing in mapped core files)
         id: fidelity
         continue-on-error: true
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@ Parity catch-up with upstream `4.26.0`. No upstream version change.
   (`test_memory_state.py`, `test_state_postgres.py`). Closes the same
   flaky-test hazard fixed for the Redis backend in PR #73.
 
+### CI / Internals
+
+- `verify_test_fidelity.py` now enforces against upstream on every PR
+  (`.github/workflows/lint.yml`); fails when the upstream clone is missing
+  or when any mapped TS file can't be found. Workflow runs `--strict` and
+  the clone step no longer carries `continue-on-error: true`, so infra
+  failures surface immediately at the job level. Baseline shipped empty
+  (all previously-missing tests ported in this release). Closes #53, #72.
+
 ## 0.4.26.1 (2026-04-23)
 
 Python-only follow-up on `0.4.26`. Still alpha — APIs may change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ Parity catch-up with upstream `4.26.0`. No upstream version change.
   (all previously-missing tests ported in this release) — strict fidelity
   for *mapped core files* (8 of 17 `packages/chat/src/*.test.ts` files;
   see the `MAPPING` dict in `scripts/verify_test_fidelity.py` for the
-  authoritative scope list). Closes #53, #72.
+  authoritative scope list). Closes #53.
 
 ## 0.4.26.1 (2026-04-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,10 @@ Parity catch-up with upstream `4.26.0`. No upstream version change.
   or when any mapped TS file can't be found. Workflow runs `--strict` and
   the clone step no longer carries `continue-on-error: true`, so infra
   failures surface immediately at the job level. Baseline shipped empty
-  (all previously-missing tests ported in this release). Closes #53, #72.
+  (all previously-missing tests ported in this release) — strict fidelity
+  for *mapped core files* (8 of 17 `packages/chat/src/*.test.ts` files;
+  see the `MAPPING` dict in `scripts/verify_test_fidelity.py` for the
+  authoritative scope list). Closes #53, #72.
 
 ## 0.4.26.1 (2026-04-23)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,3 +112,11 @@ translation fails the build, and a missing upstream checkout also fails
 mode (the default without `--strict`) is retained for local workflows
 where a few ports land in flight — regenerate via `--update-baseline`
 after documenting intentional divergence in `docs/UPSTREAM_SYNC.md`.
+
+Before the fidelity check can run locally, clone the pinned upstream
+checkout (same command CI uses in `lint.yml`):
+```bash
+git clone --depth 1 --branch chat@4.26.0 \
+  https://github.com/vercel/chat.git /tmp/vercel-chat
+```
+Then `TS_ROOT=/tmp/vercel-chat uv run python scripts/verify_test_fidelity.py --strict`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,9 @@ will not pass CI.
 
 **Fidelity check** (`scripts/verify_test_fidelity.py`) verifies every TS
 `it("...")` has a matching Python `def test_*()`, pinned to `chat@4.26.0`.
-Default mode is baseline-enforced: CI fails on any NEW miss not listed in
-`scripts/fidelity_baseline.json`. Run `--update-baseline` after porting a
-missing test (or documenting an intentional skip in `UPSTREAM_SYNC.md`). Use
-`--strict` to verify the final 0-missing target locally.
+**CI runs `--strict`** (see `.github/workflows/lint.yml`): any missing
+translation fails the build, and a missing upstream checkout also fails
+(the script exits non-zero when any mapped TS file isn't found). Baseline
+mode (the default without `--strict`) is retained for local workflows
+where a few ports land in flight — regenerate via `--update-baseline`
+after documenting intentional divergence in `docs/UPSTREAM_SYNC.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,5 +105,8 @@ async mock bugs, and cross-file duplicates. PRs that introduce hard failures
 will not pass CI.
 
 **Fidelity check** (`scripts/verify_test_fidelity.py`) verifies every TS
-`it("...")` has a matching Python `def test_*()`. Must show 0 missing before
-committing test changes.
+`it("...")` has a matching Python `def test_*()`, pinned to `chat@4.26.0`.
+Default mode is baseline-enforced: CI fails on any NEW miss not listed in
+`scripts/fidelity_baseline.json`. Run `--update-baseline` after porting a
+missing test (or documenting an intentional skip in `UPSTREAM_SYNC.md`). Use
+`--strict` to verify the final 0-missing target locally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,13 +105,17 @@ async mock bugs, and cross-file duplicates. PRs that introduce hard failures
 will not pass CI.
 
 **Fidelity check** (`scripts/verify_test_fidelity.py`) verifies every TS
-`it("...")` has a matching Python `def test_*()`, pinned to `chat@4.26.0`.
-**CI runs `--strict`** (see `.github/workflows/lint.yml`): any missing
-translation fails the build, and a missing upstream checkout also fails
-(the script exits non-zero when any mapped TS file isn't found). Baseline
-mode (the default without `--strict`) is retained for local workflows
-where a few ports land in flight — regenerate via `--update-baseline`
-after documenting intentional divergence in `docs/UPSTREAM_SYNC.md`.
+`it("...")` in the mapped core files has a matching Python `def test_*()`,
+pinned to `chat@4.26.0`. The `MAPPING` dict in that script is the
+authoritative scope list — it currently covers 8 of 17
+`packages/chat/src/*.test.ts` files (extending it is tracked as a
+follow-up). **CI runs `--strict`** (see `.github/workflows/lint.yml`):
+any missing translation in a mapped file fails the build, and a missing
+upstream checkout also fails (the script exits non-zero when any mapped
+TS file isn't found). Baseline mode (the default without `--strict`) is
+retained for local workflows where a few ports land in flight —
+regenerate via `--update-baseline` after documenting intentional
+divergence in `docs/UPSTREAM_SYNC.md`.
 
 Before the fidelity check can run locally, clone the pinned upstream
 checkout (same command CI uses in `lint.yml`):

--- a/docs/UPSTREAM_SYNC.md
+++ b/docs/UPSTREAM_SYNC.md
@@ -72,31 +72,33 @@ tests. If upstream tests lock in inconsistent behavior, choose one of:
 - **Preserve parity** and document the inconsistency in the non-parity section below
 - **Intentionally diverge** and document the divergence in the non-parity section
 
-### Test fidelity baseline
+### Test fidelity (strict mode)
 
 `scripts/verify_test_fidelity.py` runs in CI (`.github/workflows/lint.yml`) pinned
 to `vercel/chat@4.26.0` (matches the `UPSTREAM_PARITY` constant in
-`src/chat_sdk/__init__.py`). Default mode is **baseline-enforced**:
+`src/chat_sdk/__init__.py`). **CI runs `--strict`** — the repo ships at 0
+missing as of `0.4.26.2` and the baseline (`scripts/fidelity_baseline.json`)
+is empty.
 
-- The current set of missing TS-test translations lives in
-  `scripts/fidelity_baseline.json`.
-- CI fails if a TS test is missing that is **not** in the baseline (new drift).
-- CI succeeds if all currently-missing tests are a subset of the baseline — even
-  if nothing has been ported yet.
-- Fixed tests (in baseline but now ported) are reported with a reminder to
-  tighten the baseline.
+Infra guardrails:
+
+- The workflow's `Clone upstream vercel/chat at pinned parity tag` step does
+  **not** use `continue-on-error` — a failed clone aborts the job loudly.
+- The script itself fails with exit 1 if any mapped TS file is missing under
+  `TS_ROOT` (defense in depth against silent skips).
 
 Workflows:
 
 | Goal | Command |
 |------|---------|
-| Port a missing test | Write the Python test, then `--update-baseline` to remove it from the ratchet |
-| Add a Python-only divergence (intentional skip) | Document in [Known Non-Parity](#known-non-parity-with-typescript-sdk), then `--update-baseline` |
-| Upstream sync | After pulling new upstream, run default mode — any newly-added TS tests appear as NEW misses and CI fails until ported or baselined |
-| Final parity check | `--strict` ignores the baseline and fails on any missing — target once baseline hits zero |
+| Port a missing test | Write the Python test and land it; CI rejects anything that re-introduces a gap |
+| Add a Python-only divergence (intentional skip) | Document in [Known Non-Parity](#known-non-parity-with-typescript-sdk), then `--update-baseline` and switch the workflow back to non-strict default for that file if truly unavoidable |
+| Upstream sync | After pulling new upstream, run `--strict` — newly-added TS tests appear as missing and CI fails until ported |
+| Final parity check | Same as CI: `TS_ROOT=/tmp/vercel-chat uv run python scripts/verify_test_fidelity.py --strict` |
 
-The baseline file is ordered and stable so diffs are easy to review. Regenerate
-it whenever the missing set changes — don't hand-edit.
+Baseline mode (the default without `--strict`) is retained for local
+development where a few ports land in flight. Regenerate the baseline via
+`--update-baseline` rather than hand-editing.
 
 ## Divergence Policy
 

--- a/docs/UPSTREAM_SYNC.md
+++ b/docs/UPSTREAM_SYNC.md
@@ -72,6 +72,32 @@ tests. If upstream tests lock in inconsistent behavior, choose one of:
 - **Preserve parity** and document the inconsistency in the non-parity section below
 - **Intentionally diverge** and document the divergence in the non-parity section
 
+### Test fidelity baseline
+
+`scripts/verify_test_fidelity.py` runs in CI (`.github/workflows/lint.yml`) pinned
+to `vercel/chat@4.26.0` (matches the `UPSTREAM_PARITY` constant in
+`src/chat_sdk/__init__.py`). Default mode is **baseline-enforced**:
+
+- The current set of missing TS-test translations lives in
+  `scripts/fidelity_baseline.json`.
+- CI fails if a TS test is missing that is **not** in the baseline (new drift).
+- CI succeeds if all currently-missing tests are a subset of the baseline — even
+  if nothing has been ported yet.
+- Fixed tests (in baseline but now ported) are reported with a reminder to
+  tighten the baseline.
+
+Workflows:
+
+| Goal | Command |
+|------|---------|
+| Port a missing test | Write the Python test, then `--update-baseline` to remove it from the ratchet |
+| Add a Python-only divergence (intentional skip) | Document in [Known Non-Parity](#known-non-parity-with-typescript-sdk), then `--update-baseline` |
+| Upstream sync | After pulling new upstream, run default mode — any newly-added TS tests appear as NEW misses and CI fails until ported or baselined |
+| Final parity check | `--strict` ignores the baseline and fails on any missing — target once baseline hits zero |
+
+The baseline file is ordered and stable so diffs are easy to review. Regenerate
+it whenever the missing set changes — don't hand-edit.
+
 ## Divergence Policy
 
 Every divergence from upstream has a cost: merge conflicts on future syncs,

--- a/docs/UPSTREAM_SYNC.md
+++ b/docs/UPSTREAM_SYNC.md
@@ -77,8 +77,12 @@ tests. If upstream tests lock in inconsistent behavior, choose one of:
 `scripts/verify_test_fidelity.py` runs in CI (`.github/workflows/lint.yml`) pinned
 to `vercel/chat@4.26.0` (matches the `UPSTREAM_PARITY` constant in
 `src/chat_sdk/__init__.py`). **CI runs `--strict`** — the repo ships at 0
-missing as of `0.4.26.2` and the baseline (`scripts/fidelity_baseline.json`)
-is empty.
+missing *for mapped core files* as of `0.4.26.2` and the baseline
+(`scripts/fidelity_baseline.json`) is empty. Scope is defined by the
+`MAPPING` dict in the script: 8 of 17 `packages/chat/src/*.test.ts` files
+today (extending to the remaining 9 is tracked as a follow-up). Unmapped
+files are not checked — tightening scope requires editing `MAPPING` and
+re-running `--strict`.
 
 Infra guardrails:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,20 @@
 name = "chat-sdk"
 version = "0.4.26.2"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
+keywords = [
+    "chat",
+    "chatbot",
+    "chatops",
+    "slack-bot",
+    "discord-bot",
+    "telegram-bot",
+    "teams-bot",
+    "whatsapp-bot",
+    "bot-framework",
+    "async",
+    "asyncio",
+    "vercel",
+]
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
@@ -16,7 +30,11 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Topic :: Communications",
     "Topic :: Communications :: Chat",
+    "Topic :: Internet",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
 

--- a/scripts/fidelity_baseline.json
+++ b/scripts/fidelity_baseline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Ratchet-down baseline for scripts/verify_test_fidelity.py. This repo ships at strict fidelity (0 missing) against chat@4.26.0, so the baseline is empty. Default CI mode now runs --strict via .github/workflows/lint.yml; this file is retained for local workflows that want to opt back into baseline mode (e.g. during an upstream sync where several ports land in flight). To baseline genuinely-divergent tests, run scripts/verify_test_fidelity.py --update-baseline after documenting the divergence in docs/UPSTREAM_SYNC.md.",
+  "_comment": "Ratchet-down baseline for scripts/verify_test_fidelity.py. This repo ships at strict fidelity for mapped core files (0 missing) against chat@4.26.0, so the baseline is empty. Scope: the MAPPING dict in scripts/verify_test_fidelity.py is the authoritative list of TS files checked; it currently covers 8 of the 17 packages/chat/src/*.test.ts files. Default CI mode runs --strict via .github/workflows/lint.yml; this file is retained for local workflows that want to opt back into baseline mode (e.g. during an upstream sync where several ports land in flight). To baseline genuinely-divergent tests, run scripts/verify_test_fidelity.py --update-baseline after documenting the divergence in docs/UPSTREAM_SYNC.md.",
   "ts_parity": "chat@4.26.0",
   "total_ts_tests": 588,
   "total_missing": 0,

--- a/scripts/fidelity_baseline.json
+++ b/scripts/fidelity_baseline.json
@@ -1,0 +1,74 @@
+{
+  "_comment": "Ratchet-down baseline for scripts/verify_test_fidelity.py. Each entry is a [describe_block, ts_it_name] pair that is known to be missing a Python translation. Default CI mode accepts any subset of this list as missing and fails on new misses outside it. To remove entries: port the TS test to its Python counterpart, then regenerate this file with --update-baseline.",
+  "ts_parity": "chat@4.26.0",
+  "total_ts_tests": 564,
+  "total_missing": 16,
+  "missing": {
+    "packages/chat/src/thread.test.ts": [
+      [
+        "post with Plan",
+        "should add tasks and call editObject"
+      ],
+      [
+        "post with Plan",
+        "should call adapter postObject when supported"
+      ],
+      [
+        "post with Plan",
+        "should complete plan and mark tasks done"
+      ],
+      [
+        "post with Plan",
+        "should complete plan via editMessage in fallback mode"
+      ],
+      [
+        "post with Plan",
+        "should continue accepting edits after a failed edit"
+      ],
+      [
+        "post with Plan",
+        "should ensure sequential edits via queue"
+      ],
+      [
+        "post with Plan",
+        "should handle various PlanContent formats in initialMessage"
+      ],
+      [
+        "post with Plan",
+        "should post fallback text when adapter does not support plans"
+      ],
+      [
+        "post with Plan",
+        "should propagate editObject errors from addTask"
+      ],
+      [
+        "post with Plan",
+        "should reset plan and start fresh"
+      ],
+      [
+        "post with Plan",
+        "should return null when calling addTask before post"
+      ],
+      [
+        "post with Plan",
+        "should return null when calling complete before post"
+      ],
+      [
+        "post with Plan",
+        "should return null when calling updateTask before post"
+      ],
+      [
+        "post with Plan",
+        "should set error status via updateTask"
+      ],
+      [
+        "post with Plan",
+        "should update current task with output"
+      ],
+      [
+        "post with Plan",
+        "should update via editMessage in fallback mode"
+      ]
+    ]
+  }
+}

--- a/scripts/fidelity_baseline.json
+++ b/scripts/fidelity_baseline.json
@@ -1,74 +1,7 @@
 {
-  "_comment": "Ratchet-down baseline for scripts/verify_test_fidelity.py. Each entry is a [describe_block, ts_it_name] pair that is known to be missing a Python translation. Default CI mode accepts any subset of this list as missing and fails on new misses outside it. To remove entries: port the TS test to its Python counterpart, then regenerate this file with --update-baseline.",
+  "_comment": "Ratchet-down baseline for scripts/verify_test_fidelity.py. This repo ships at strict fidelity (0 missing) against chat@4.26.0, so the baseline is empty. Default CI mode now runs --strict via .github/workflows/lint.yml; this file is retained for local workflows that want to opt back into baseline mode (e.g. during an upstream sync where several ports land in flight). To baseline genuinely-divergent tests, run scripts/verify_test_fidelity.py --update-baseline after documenting the divergence in docs/UPSTREAM_SYNC.md.",
   "ts_parity": "chat@4.26.0",
-  "total_ts_tests": 564,
-  "total_missing": 16,
-  "missing": {
-    "packages/chat/src/thread.test.ts": [
-      [
-        "post with Plan",
-        "should add tasks and call editObject"
-      ],
-      [
-        "post with Plan",
-        "should call adapter postObject when supported"
-      ],
-      [
-        "post with Plan",
-        "should complete plan and mark tasks done"
-      ],
-      [
-        "post with Plan",
-        "should complete plan via editMessage in fallback mode"
-      ],
-      [
-        "post with Plan",
-        "should continue accepting edits after a failed edit"
-      ],
-      [
-        "post with Plan",
-        "should ensure sequential edits via queue"
-      ],
-      [
-        "post with Plan",
-        "should handle various PlanContent formats in initialMessage"
-      ],
-      [
-        "post with Plan",
-        "should post fallback text when adapter does not support plans"
-      ],
-      [
-        "post with Plan",
-        "should propagate editObject errors from addTask"
-      ],
-      [
-        "post with Plan",
-        "should reset plan and start fresh"
-      ],
-      [
-        "post with Plan",
-        "should return null when calling addTask before post"
-      ],
-      [
-        "post with Plan",
-        "should return null when calling complete before post"
-      ],
-      [
-        "post with Plan",
-        "should return null when calling updateTask before post"
-      ],
-      [
-        "post with Plan",
-        "should set error status via updateTask"
-      ],
-      [
-        "post with Plan",
-        "should update current task with output"
-      ],
-      [
-        "post with Plan",
-        "should update via editMessage in fallback mode"
-      ]
-    ]
-  }
+  "total_ts_tests": 588,
+  "total_missing": 0,
+  "missing": {}
 }

--- a/scripts/verify_test_fidelity.py
+++ b/scripts/verify_test_fidelity.py
@@ -270,14 +270,19 @@ def load_baseline(path: Path) -> dict[str, set[tuple[str, str]]]:
 
 
 _DEFAULT_BASELINE_COMMENT = (
-    "Ratchet-down baseline for scripts/verify_test_fidelity.py. "
-    "Each entry is a [describe_block, ts_it_name] pair that is known "
-    "to be missing a Python translation. CI runs --strict (see "
-    ".github/workflows/lint.yml) and ignores this file; baseline "
-    "mode is a local-dev opt-in that accepts any subset of this "
-    "list as missing and fails on new misses outside it. To remove "
-    "entries: port the TS test to its Python counterpart, then "
-    "regenerate this file with --update-baseline."
+    "Ratchet-down baseline for scripts/verify_test_fidelity.py. This "
+    "repo ships at strict fidelity for mapped core files (0 missing) "
+    "against the current UPSTREAM_PARITY tag, so the baseline is "
+    "normally empty. Scope: the MAPPING dict in "
+    "scripts/verify_test_fidelity.py is the authoritative list of TS "
+    "files checked; it currently covers 8 of the 17 "
+    "packages/chat/src/*.test.ts files. Default CI mode runs --strict "
+    "via .github/workflows/lint.yml; this file is retained for local "
+    "workflows that want to opt back into baseline mode (e.g. during "
+    "an upstream sync where several ports land in flight). To "
+    "baseline genuinely-divergent tests, run "
+    "scripts/verify_test_fidelity.py --update-baseline after "
+    "documenting the divergence in docs/UPSTREAM_SYNC.md."
 )
 
 
@@ -299,9 +304,14 @@ def write_baseline(path: Path, all_missing: dict[str, list], total_ts: int) -> N
         except (OSError, json.JSONDecodeError):
             existing_comment = None
 
+    # Derive ts_parity from UPSTREAM_PARITY so a fresh regen after an
+    # upstream version bump doesn't self-trap on a stale literal. Fall
+    # back to the last-known literal only if UPSTREAM_PARITY can't be
+    # read (e.g. __init__.py missing during an in-flight refactor).
+    current_parity = _current_parity_tag()
     payload = {
         "_comment": existing_comment if existing_comment is not None else _DEFAULT_BASELINE_COMMENT,
-        "ts_parity": "chat@4.26.0",
+        "ts_parity": current_parity if current_parity is not None else "chat@4.26.0",
         "total_ts_tests": total_ts,
         "total_missing": sum(len(v) for v in all_missing.values()),
         "missing": {

--- a/scripts/verify_test_fidelity.py
+++ b/scripts/verify_test_fidelity.py
@@ -6,11 +6,20 @@ snake_case, and checks that a corresponding def test_...() exists in the
 Python translation.
 
 Usage:
-    python scripts/verify_test_fidelity.py [--fix]
+    python scripts/verify_test_fidelity.py             # baseline mode (default)
+    python scripts/verify_test_fidelity.py --strict    # fail on any missing
+    python scripts/verify_test_fidelity.py --fix       # append stubs for missing
+    python scripts/verify_test_fidelity.py --update-baseline  # rewrite baseline
 
-With --fix: appends stub test functions for any missing translations.
+Default (baseline) mode: succeeds iff the set of missing tests is a subset of
+``scripts/fidelity_baseline.json``. Tests that are in the baseline but now pass
+are reported as fixed. New misses outside the baseline fail CI.
+
+``--strict`` ignores the baseline and fails on any missing. This is the
+eventual target once the baseline count ratchets to zero.
 """
 
+import json
 import os
 import re
 import sys
@@ -18,6 +27,7 @@ from pathlib import Path
 
 TS_ROOT = os.environ.get("TS_ROOT", "/tmp/vercel-chat")
 PY_ROOT = os.environ.get("PY_ROOT", str(Path(__file__).parent.parent))
+BASELINE_PATH = Path(__file__).parent / "fidelity_baseline.json"
 
 # Mapping: TS test file -> Python test file
 MAPPING = {
@@ -205,15 +215,66 @@ def count_absorbers(py_path: str) -> int:
     return count
 
 
+def load_baseline(path: Path) -> dict[str, set[tuple[str, str]]]:
+    """Load fidelity baseline. Missing file returns empty baseline."""
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        data = json.load(f)
+    out: dict[str, set[tuple[str, str]]] = {}
+    for ts_rel, entries in data.get("missing", {}).items():
+        out[ts_rel] = {(e[0], e[1]) for e in entries}
+    return out
+
+
+def write_baseline(path: Path, all_missing: dict[str, list], total_ts: int) -> None:
+    """Persist the current set of missing tests as the new baseline."""
+    payload = {
+        "_comment": (
+            "Ratchet-down baseline for scripts/verify_test_fidelity.py. "
+            "Each entry is a [describe_block, ts_it_name] pair that is known "
+            "to be missing a Python translation. Default CI mode accepts any "
+            "subset of this list as missing and fails on new misses outside "
+            "it. To remove entries: port the TS test to its Python counterpart, "
+            "then regenerate this file with --update-baseline."
+        ),
+        "ts_parity": "chat@4.26.0",
+        "total_ts_tests": total_ts,
+        "total_missing": sum(len(v) for v in all_missing.values()),
+        "missing": {
+            ts_rel: [[d, t] for d, t, _p in sorted(entries, key=lambda e: (e[0], e[1]))]
+            for ts_rel, entries in sorted(all_missing.items())
+            if entries
+        },
+    }
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2, sort_keys=False)
+        f.write("\n")
+
+
 def main() -> int:
     fix_mode = "--fix" in sys.argv
+    strict_mode = "--strict" in sys.argv
+    update_baseline = "--update-baseline" in sys.argv
+
+    baseline = {} if (strict_mode or update_baseline) else load_baseline(BASELINE_PATH)
+
     total_missing = 0
     total_matched = 0
     total_ts = 0
     total_absorbers = 0
+    all_missing: dict[str, list] = {}
+    new_misses: dict[str, list[tuple[str, str]]] = {}
+    fixed: dict[str, list[tuple[str, str]]] = {}
 
     print("=" * 70)
     print("TEST FIDELITY REPORT")
+    if strict_mode:
+        print("  mode: --strict (baseline ignored)")
+    elif update_baseline:
+        print("  mode: --update-baseline (rewriting baseline)")
+    else:
+        print(f"  mode: baseline ({BASELINE_PATH.name})")
     print("=" * 70)
 
     for ts_rel, py_rel in MAPPING.items():
@@ -231,6 +292,16 @@ def main() -> int:
         total_matched += matched
         total_missing += len(missing)
         total_absorbers += absorbers
+        all_missing[ts_rel] = missing
+
+        current_missing_keys = {(d, t) for d, t, _p in missing}
+        baseline_keys = baseline.get(ts_rel, set())
+        file_new = sorted(current_missing_keys - baseline_keys)
+        file_fixed = sorted(baseline_keys - current_missing_keys)
+        if file_new:
+            new_misses[ts_rel] = file_new
+        if file_fixed:
+            fixed[ts_rel] = file_fixed
 
         absorber_note = f" ({absorbers} absorbers)" if absorbers else ""
         status = "OK" if not missing else f"GAPS ({len(missing)})"
@@ -243,7 +314,8 @@ def main() -> int:
 
         if missing:
             for describe, ts_name, _py_name in missing[:5]:
-                print(f"    MISSING: [{describe}] {ts_name}")
+                marker = "NEW" if (describe, ts_name) in set(file_new) else "baselined"
+                print(f"    MISSING ({marker}): [{describe}] {ts_name}")
             if len(missing) > 5:
                 print(f"    ... and {len(missing) - 5} more")
 
@@ -272,10 +344,48 @@ def main() -> int:
     else:
         print(f"TOTAL: {total_matched}/{total_ts} matched ({pct}%), {total_missing} missing")
 
-    if total_missing > 0:
-        print("\nRun with --fix to generate stubs for missing tests.")
+    if update_baseline:
+        write_baseline(BASELINE_PATH, all_missing, total_ts)
+        print(f"\nBaseline written to {BASELINE_PATH}")
+        print(f"  {total_missing} missing tests baselined across {sum(1 for v in all_missing.values() if v)} files")
+        return 0
+
+    if total_missing == 0:
+        print("\nAll TS tests have Python equivalents.")
+        if any(baseline.values()):
+            print("Baseline is stale — run with --update-baseline to clear it.")
+        return 0
+
+    if strict_mode:
+        print(f"\n{total_missing} missing (strict mode — baseline ignored).")
+        print("Run with --fix to generate stubs for missing tests.")
         return 1
-    print("\nAll TS tests have Python equivalents.")
+
+    if new_misses:
+        new_count = sum(len(v) for v in new_misses.values())
+        print(f"\n{new_count} NEW miss(es) outside the baseline:")
+        for ts_rel, entries in new_misses.items():
+            for describe, ts_name in entries:
+                print(f"  - {ts_rel} :: [{describe}] {ts_name}")
+        print("\nOptions:")
+        print("  1. Port the missing TS test(s) to the matching Python file")
+        print("  2. If intentional divergence, document in docs/UPSTREAM_SYNC.md")
+        print("     and re-baseline with --update-baseline")
+        print("\nRun with --fix to generate Python stubs for missing tests.")
+        return 1
+
+    if fixed:
+        fixed_count = sum(len(v) for v in fixed.values())
+        print(f"\n✓ {fixed_count} test(s) fixed since baseline (no longer missing):")
+        for _ts_rel, entries in fixed.items():
+            for describe, ts_name in entries[:5]:
+                print(f"    - [{describe}] {ts_name}")
+            if len(entries) > 5:
+                print(f"    ... and {len(entries) - 5} more")
+        print("\nRun with --update-baseline to tighten the baseline.")
+
+    baseline_total = sum(len(v) for v in baseline.values())
+    print(f"\n{total_missing}/{baseline_total} baseline miss(es) still present — no new drift.")
     return 0
 
 

--- a/scripts/verify_test_fidelity.py
+++ b/scripts/verify_test_fidelity.py
@@ -266,19 +266,38 @@ def load_baseline(path: Path) -> dict[str, set[tuple[str, str]]]:
     return out
 
 
+_DEFAULT_BASELINE_COMMENT = (
+    "Ratchet-down baseline for scripts/verify_test_fidelity.py. "
+    "Each entry is a [describe_block, ts_it_name] pair that is known "
+    "to be missing a Python translation. CI runs --strict (see "
+    ".github/workflows/lint.yml) and ignores this file; baseline "
+    "mode is a local-dev opt-in that accepts any subset of this "
+    "list as missing and fails on new misses outside it. To remove "
+    "entries: port the TS test to its Python counterpart, then "
+    "regenerate this file with --update-baseline."
+)
+
+
 def write_baseline(path: Path, all_missing: dict[str, list], total_ts: int) -> None:
-    """Persist the current set of missing tests as the new baseline."""
+    """Persist the current set of missing tests as the new baseline.
+
+    If ``path`` already exists and has a ``_comment`` field, that curated
+    comment is preserved so hand-written context (e.g. scope qualifiers,
+    shipping-posture notes) isn't silently overwritten on every
+    ``--update-baseline`` run. Only fresh files get the default boilerplate.
+    """
+    existing_comment: str | None = None
+    if path.exists():
+        try:
+            with open(path) as f:
+                existing = json.load(f)
+            if isinstance(existing.get("_comment"), str):
+                existing_comment = existing["_comment"]
+        except (OSError, json.JSONDecodeError):
+            existing_comment = None
+
     payload = {
-        "_comment": (
-            "Ratchet-down baseline for scripts/verify_test_fidelity.py. "
-            "Each entry is a [describe_block, ts_it_name] pair that is known "
-            "to be missing a Python translation. CI runs --strict (see "
-            ".github/workflows/lint.yml) and ignores this file; baseline "
-            "mode is a local-dev opt-in that accepts any subset of this "
-            "list as missing and fails on new misses outside it. To remove "
-            "entries: port the TS test to its Python counterpart, then "
-            "regenerate this file with --update-baseline."
-        ),
+        "_comment": existing_comment if existing_comment is not None else _DEFAULT_BASELINE_COMMENT,
         "ts_parity": "chat@4.26.0",
         "total_ts_tests": total_ts,
         "total_missing": sum(len(v) for v in all_missing.values()),

--- a/scripts/verify_test_fidelity.py
+++ b/scripts/verify_test_fidelity.py
@@ -266,6 +266,7 @@ def main() -> int:
     all_missing: dict[str, list] = {}
     new_misses: dict[str, list[tuple[str, str]]] = {}
     fixed: dict[str, list[tuple[str, str]]] = {}
+    missing_ts_files: list[str] = []
 
     print("=" * 70)
     print("TEST FIDELITY REPORT")
@@ -280,7 +281,8 @@ def main() -> int:
     for ts_rel, py_rel in MAPPING.items():
         ts_path = os.path.join(TS_ROOT, ts_rel)
         if not os.path.exists(ts_path):
-            print(f"\n{ts_rel} — SKIPPED (file not found)")
+            print(f"\n{ts_rel} — MISSING (upstream TS file not found at {ts_path})")
+            missing_ts_files.append(ts_path)
             continue
 
         ts_tests = extract_ts_tests(ts_path)
@@ -343,6 +345,24 @@ def main() -> int:
         print(f"  Real tests: {real_total} | Absorbers: {total_absorbers}")
     else:
         print(f"TOTAL: {total_matched}/{total_ts} matched ({pct}%), {total_missing} missing")
+
+    # Infra guard: if any mapped TS file is missing, we cannot verify fidelity.
+    # Do NOT treat this as success — a failed upstream clone would otherwise
+    # silently pass CI. Fail loudly before any downstream success branches.
+    if missing_ts_files:
+        print(
+            f"\nupstream checkout missing — cannot verify fidelity. "
+            f"{len(missing_ts_files)} mapped TS file(s) not found under TS_ROOT={TS_ROOT!r}:"
+        )
+        for path in missing_ts_files:
+            print(f"  - {path}")
+        print(
+            "\nClone the upstream repo at the pinned parity tag, e.g.:\n"
+            "  git clone --depth 1 --branch chat@4.26.0 "
+            "https://github.com/vercel/chat.git /tmp/vercel-chat\n"
+            "then re-run with TS_ROOT=/tmp/vercel-chat."
+        )
+        return 1
 
     if update_baseline:
         write_baseline(BASELINE_PATH, all_missing, total_ts)

--- a/scripts/verify_test_fidelity.py
+++ b/scripts/verify_test_fidelity.py
@@ -13,8 +13,11 @@ Usage:
 
 ``--strict`` is the current CI contract (see ``.github/workflows/lint.yml``):
 the baseline is ignored and any missing translation — or a missing upstream
-checkout — fails the build. This repo ships at zero missing against
-``chat@4.26.0``.
+checkout — fails the build. This repo ships at strict fidelity for mapped
+core files (0 missing) against ``chat@4.26.0``. The ``MAPPING`` dict below
+is the authoritative scope list; it currently covers 8 of the 17
+``packages/chat/src/*.test.ts`` files (extending it is tracked as a
+follow-up).
 
 Baseline mode (the default without ``--strict``) is retained for local
 workflows where a few ports land in flight: it succeeds iff the set of

--- a/scripts/verify_test_fidelity.py
+++ b/scripts/verify_test_fidelity.py
@@ -6,17 +6,22 @@ snake_case, and checks that a corresponding def test_...() exists in the
 Python translation.
 
 Usage:
-    python scripts/verify_test_fidelity.py             # baseline mode (default)
-    python scripts/verify_test_fidelity.py --strict    # fail on any missing
+    python scripts/verify_test_fidelity.py --strict    # CI path: fail on any missing
+    python scripts/verify_test_fidelity.py             # baseline mode (local opt-in)
     python scripts/verify_test_fidelity.py --fix       # append stubs for missing
     python scripts/verify_test_fidelity.py --update-baseline  # rewrite baseline
 
-Default (baseline) mode: succeeds iff the set of missing tests is a subset of
-``scripts/fidelity_baseline.json``. Tests that are in the baseline but now pass
-are reported as fixed. New misses outside the baseline fail CI.
+``--strict`` is the current CI contract (see ``.github/workflows/lint.yml``):
+the baseline is ignored and any missing translation — or a missing upstream
+checkout — fails the build. This repo ships at zero missing against
+``chat@4.26.0``.
 
-``--strict`` ignores the baseline and fails on any missing. This is the
-eventual target once the baseline count ratchets to zero.
+Baseline mode (the default without ``--strict``) is retained for local
+workflows where a few ports land in flight: it succeeds iff the set of
+missing tests is a subset of ``scripts/fidelity_baseline.json``. Tests that
+are in the baseline but now pass are reported as fixed; new misses outside
+the baseline fail. Regenerate via ``--update-baseline`` after documenting
+intentional divergence in ``docs/UPSTREAM_SYNC.md``.
 """
 
 import json
@@ -215,12 +220,46 @@ def count_absorbers(py_path: str) -> int:
     return count
 
 
+def _current_parity_tag() -> str | None:
+    """Return the baseline-format parity tag (``chat@X.Y.Z``) for the current repo.
+
+    Reads ``UPSTREAM_PARITY`` from ``src/chat_sdk/__init__.py`` without
+    importing the package (avoids pulling optional runtime deps during a
+    script run). Returns None if the constant can't be located.
+    """
+    init_path = Path(__file__).parent.parent / "src" / "chat_sdk" / "__init__.py"
+    if not init_path.exists():
+        return None
+    with open(init_path) as f:
+        content = f.read()
+    m = re.search(r'^UPSTREAM_PARITY\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    if not m:
+        return None
+    return f"chat@{m.group(1)}"
+
+
 def load_baseline(path: Path) -> dict[str, set[tuple[str, str]]]:
-    """Load fidelity baseline. Missing file returns empty baseline."""
+    """Load fidelity baseline. Missing file returns empty baseline.
+
+    Exits with code 1 when the baseline's ``ts_parity`` disagrees with the
+    current ``UPSTREAM_PARITY`` constant — a stale baseline could otherwise
+    silently mask upstream drift after a version bump.
+    """
     if not path.exists():
         return {}
     with open(path) as f:
         data = json.load(f)
+    baseline_parity = data.get("ts_parity")
+    current_parity = _current_parity_tag()
+    if baseline_parity and current_parity and baseline_parity != current_parity:
+        print(
+            f"\nbaseline parity mismatch: {path.name} was generated for "
+            f"upstream {baseline_parity}, but current parity is "
+            f"{current_parity} — re-run with `--update-baseline` after "
+            f"confirming the diff.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     out: dict[str, set[tuple[str, str]]] = {}
     for ts_rel, entries in data.get("missing", {}).items():
         out[ts_rel] = {(e[0], e[1]) for e in entries}
@@ -233,10 +272,12 @@ def write_baseline(path: Path, all_missing: dict[str, list], total_ts: int) -> N
         "_comment": (
             "Ratchet-down baseline for scripts/verify_test_fidelity.py. "
             "Each entry is a [describe_block, ts_it_name] pair that is known "
-            "to be missing a Python translation. Default CI mode accepts any "
-            "subset of this list as missing and fails on new misses outside "
-            "it. To remove entries: port the TS test to its Python counterpart, "
-            "then regenerate this file with --update-baseline."
+            "to be missing a Python translation. CI runs --strict (see "
+            ".github/workflows/lint.yml) and ignores this file; baseline "
+            "mode is a local-dev opt-in that accepts any subset of this "
+            "list as missing and fails on new misses outside it. To remove "
+            "entries: port the TS test to its Python counterpart, then "
+            "regenerate this file with --update-baseline."
         ),
         "ts_parity": "chat@4.26.0",
         "total_ts_tests": total_ts,
@@ -256,6 +297,15 @@ def main() -> int:
     fix_mode = "--fix" in sys.argv
     strict_mode = "--strict" in sys.argv
     update_baseline = "--update-baseline" in sys.argv
+
+    if strict_mode and update_baseline:
+        print(
+            "error: --strict and --update-baseline are mutually exclusive.\n"
+            "  --strict says 'no missing allowed'; --update-baseline says "
+            "'snapshot whatever is missing into the allowlist'. Pick one.",
+            file=sys.stderr,
+        )
+        return 2
 
     baseline = {} if (strict_mode or update_baseline) else load_baseline(BASELINE_PATH)
 

--- a/src/chat_sdk/adapters/teams/format_converter.py
+++ b/src/chat_sdk/adapters/teams/format_converter.py
@@ -22,11 +22,7 @@ from chat_sdk.shared.base_format_converter import (
     get_node_value,
     parse_markdown,
 )
-
-
-def _escape_table_cell(value: str) -> str:
-    """Escape pipe characters in table cells for GFM rendering."""
-    return value.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+from chat_sdk.shared.card_utils import escape_table_cell
 
 
 class TeamsFormatConverter(BaseFormatConverter):
@@ -194,11 +190,11 @@ class TeamsFormatConverter(BaseFormatConverter):
 
         lines: list[str] = []
         # Header row
-        lines.append(f"| {' | '.join(_escape_table_cell(c) for c in rows[0])} |")
+        lines.append(f"| {' | '.join(escape_table_cell(c) for c in rows[0])} |")
         # Separator
         separators = ["---"] * len(rows[0])
         lines.append(f"| {' | '.join(separators)} |")
         # Data rows
         for row in rows[1:]:
-            lines.append(f"| {' | '.join(_escape_table_cell(c) for c in row)} |")
+            lines.append(f"| {' | '.join(escape_table_cell(c) for c in row)} |")
         return "\n".join(lines)

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -8,6 +8,7 @@ from chat_sdk.cards import (
     is_card_element,
     table_element_to_ascii,
 )
+from chat_sdk.shared.card_utils import escape_table_cell, render_gfm_table
 
 
 class TestIsCardElement:
@@ -159,3 +160,51 @@ class TestCardChildToFallbackText:
     def test_button_element_returns_none(self):
         child = {"type": "button", "label": "Click me"}
         assert card_child_to_fallback_text(child) is None
+
+
+class TestEscapeTableCell:
+    """Tests for shared.card_utils.escape_table_cell."""
+
+    def test_plain_text_passthrough(self):
+        assert escape_table_cell("hello world") == "hello world"
+
+    def test_pipe_escaped(self):
+        assert escape_table_cell("a|b") == r"a\|b"
+
+    def test_backslash_doubled_before_pipe_escape(self):
+        # Backslash must be doubled FIRST so that a literal `\|` in input
+        # doesn't collide with the subsequent pipe-escape.
+        assert escape_table_cell(r"a\b") == r"a\\b"
+        assert escape_table_cell(r"a\|b") == r"a\\\|b"
+
+    def test_newline_collapsed_to_space(self):
+        assert escape_table_cell("line1\nline2") == "line1 line2"
+
+    def test_multiple_substitutions(self):
+        assert escape_table_cell("a|b\nc\\d") == r"a\|b c\\d"
+
+    def test_empty_string(self):
+        assert escape_table_cell("") == ""
+
+
+class TestRenderGfmTable:
+    """Tests for shared.card_utils.render_gfm_table."""
+
+    def test_basic_table(self):
+        lines = render_gfm_table(["h1", "h2"], [["a", "b"], ["c", "d"]])
+        assert lines == [
+            "| h1 | h2 |",
+            "| --- | --- |",
+            "| a | b |",
+            "| c | d |",
+        ]
+
+    def test_cells_are_escaped(self):
+        lines = render_gfm_table(["col"], [["pipe|inside"], ["has\nnewline"]])
+        assert r"pipe\|inside" in lines[2]
+        assert "has newline" in lines[3]
+
+    def test_empty_rows(self):
+        # No data rows — only header + separator.
+        lines = render_gfm_table(["only"], [])
+        assert lines == ["| only |", "| --- |"]


### PR DESCRIPTION
Closes #53.

## Summary

`scripts/verify_test_fidelity.py` already exited non-zero on missing tests, but nothing in CI invoked it. Upstream-TS-test translations drifted undetected: 16 gaps against the pinned `chat@4.26.0` tag at the time #53 was filed.

This PR wires the check into CI. Every one of those 16 gaps has since been ported by other PRs in the 0.4.26.2 bundle (#74, #75), so CI now runs in **strict mode** with an empty baseline.

## What changed

### Script (`scripts/verify_test_fidelity.py`)

Flags:
- **Default mode**: baseline-enforced (retained for local dev during upstream syncs). Reads `scripts/fidelity_baseline.json`. Passes if the set of missing tests is a subset of the baseline. Fails on any **new** miss outside it.
- `--strict`: ignore baseline, fail on any missing. **This is what CI runs.**
- `--update-baseline`: regenerate the baseline file from the current state.

**Infra guardrail:** if any mapped TS test file is missing under `TS_ROOT` (e.g. upstream clone failed or wrong path), the script fails with exit 1 and a clear "upstream checkout missing — cannot verify fidelity" message naming every missing path. Before this guardrail, a missing checkout produced a silent 0/0 pass with "All TS tests have Python equivalents." Applies in every mode including `--strict` and `--update-baseline`, before any success branches.

Reproducer:
```
$ TS_ROOT=/tmp/definitely-missing uv run python scripts/verify_test_fidelity.py; echo "exit=$?"
... exit=1 with the "upstream checkout missing" message
```

### Baseline (`scripts/fidelity_baseline.json`)

Shipped empty — `{"missing": {}}`. The 16 `[post with Plan]` gaps that originally populated it were ported in #75, and the 6 `[Streaming]` StreamingPlan tests in #74. The file is kept (not deleted) so `--update-baseline` and the baseline-mode workflow still function for future syncs.

### CI (`.github/workflows/lint.yml`)

Two new steps:
1. `Clone upstream vercel/chat at pinned parity tag` — shallow clone of `chat@4.26.0` to `/tmp/vercel-chat`. **No `continue-on-error`** — a failed clone aborts the job loudly at the infra layer.
2. `Test fidelity check (strict — zero missing)` — runs `verify_test_fidelity.py --strict` with `TS_ROOT=/tmp/vercel-chat`. Still `continue-on-error: true` so its outcome flows through the existing aggregate-failure gate alongside ruff, audit, and pyrefly.

Defense in depth: if the clone ever regresses to `continue-on-error: true` in a future edit, the script-level guardrail still fails the fidelity step.

### Docs

- `docs/UPSTREAM_SYNC.md` **Test fidelity (strict mode)** subsection rewritten — documents strict as the CI default, lists the two infra guardrails, and keeps the baseline-mode procedure for future upstream syncs.
- `CLAUDE.md` fidelity paragraph rewritten accordingly.
- `CHANGELOG.md` gains a `### CI / Internals` entry under `0.4.26.2` describing the wiring, the guardrails, and the empty baseline.

## Self-review gaps closed

An earlier iteration of this PR (before rebasing onto the 0.4.26.2 bundle) shipped baseline mode with:
1. The script silently skipping missing TS files and reporting 0/0 pass — now fails exit 1.
2. `continue-on-error: true` on the clone step combined with (1) → failed clone silently passes CI — `continue-on-error` is now removed from the clone.

Both are fixed in this revision. See the `ci(fidelity): fail script when mapped TS files are missing` and `ci(fidelity): drop continue-on-error on clone, run --strict with empty baseline` commits.

## Verification

```
$ TS_ROOT=/private/tmp/vercel-chat uv run python scripts/verify_test_fidelity.py --strict → exit 0, 588/588 matched, 0 missing
$ TS_ROOT=/tmp/definitely-missing-vercel-chat uv run python scripts/verify_test_fidelity.py → exit 1, "upstream checkout missing" message
$ uv run ruff check src/ tests/ scripts/ → All checks passed
$ uv run ruff format --check src/ tests/ scripts/ → 193 files already formatted
$ uv run pyrefly check → 0 errors
$ uv run python scripts/audit_test_quality.py → Hard failures: 0
$ uv run pytest tests/ --tb=short -q → 3640 passed, 2 skipped
```

## Test plan

- [ ] CI `Lint & Type Check` workflow: `Test fidelity` step shows `TOTAL: 588/588 matched (100%), 0 missing` in strict mode.
- [ ] Simulate missing-clone in a scratch branch (`TS_ROOT=/tmp/bogus`): confirm CI's `Test fidelity` step fails with `exit 1` and the `upstream checkout missing` message, and that the aggregate-failure gate fails the job.
- [ ] Simulate failed clone (break the branch name on the clone step in a scratch branch): confirm the job aborts at the clone step, not silently continues.

https://claude.ai/code/session_01WhrgpELQJJSakBnwSNuwGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhrgpELQJJSakBnwSNuwGJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Baseline-driven test-fidelity check with strict mode and baseline update; CI fails on new missing translations by default.
  * Added unit tests for shared table-rendering utilities.

* **CI / Workflows**
  * Fidelity check integrated into workflow reporting and final gating; upstream parity clone is required for strict validation.

* **Documentation**
  * Expanded guidance for fidelity checks, baseline maintenance, and upstream sync procedures.

* **Packaging**
  * Expanded package metadata keywords and classifiers.

* **Refactor**
  * Unified table-cell escaping to a shared utility for consistent rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->