### PR TITLE
chore: release 0.4.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
-## Unreleased
+## 0.4.26.2 (2026-04-24)
 
-<<<<<<< HEAD
 Parity catch-up with upstream `4.26.0`. No upstream version change.
 
 ### New public APIs
@@ -78,7 +77,7 @@ Parity catch-up with upstream `4.26.0`. No upstream version change.
 
 ### Fixes
 
-- **`Plan.update_task(input)` / `StreamingPlan.update_task(input)` now honor `input.id`** — previously only worked on the last in-progress task; with `id` set, targets that specific task and returns `None` for unknown IDs. Matches upstream `UpdateTaskInput` semantics.
+- **`Plan.update_task(input)` now honors `input.id`** — previously only worked on the last in-progress task; with `id` set, targets that specific task and returns `None` for unknown IDs. Matches upstream `UpdateTaskInput` semantics.
 - **`Plan.add_task()` / `update_task()` now propagate `adapter.edit_object` errors** — previously swallowed and logged; upstream returns the chained promise so callers see failures.
 - **Plan edit queue is now actually sequential under concurrency** — previously racy under `asyncio.gather`; rewrote `_enqueue_edit` to build the chain synchronously before awaiting, matching upstream TS's `.then`-based chain. Fixes out-of-order edits when multiple `add_task`/`update_task` calls interleave.
 - **`StreamingPlan` options now wired through `Thread.post()`** — the Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-sdk"
-version = "0.4.26.1"
+version = "0.4.26.2"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/chat_sdk/adapters/slack/adapter.py
+++ b/src/chat_sdk/adapters/slack/adapter.py
@@ -1055,6 +1055,9 @@ class SlackAdapter:
         # Use asyncio.shield so the orphaned task still runs (and logs errors)
         # if we time out. `wait_for` cancels the awaitable on timeout; shielding
         # prevents that cancellation from propagating into the handler task.
+        # Use asyncio.ensure_future — process_options_load is typed as returning
+        # Awaitable (matching sibling process_* methods on the ChatInstance
+        # Protocol); create_task() would require narrowing to Coroutine.
         load_task = asyncio.ensure_future(self._chat.process_options_load(event, options))
 
         try:

--- a/tests/test_thread_faithful.py
+++ b/tests/test_thread_faithful.py
@@ -1747,18 +1747,11 @@ class TestPostWithPlan:
 
     Ported from TS thread.test.ts to close the fidelity gap tracked in #55.
 
-    Note: a few tests in this block expose known behavior gaps between the
-    current Python ``Plan`` implementation and the upstream TS version:
-
-    * ``UpdateTaskInput`` in ``plan.py`` has no ``id`` field, so looking up
-      a task by id via ``update_task({"id": ...})`` is not supported.
-    * ``_enqueue_edit`` swallows adapter errors instead of propagating them
-      to the caller (upstream returns the chained promise, which rejects).
-    * The edit chain is rebuilt post-await rather than synchronously, which
-      does not preserve strict ordering under ``asyncio.gather``.
-
-    Those tests are skipped with a pointer back here so the gaps remain
-    visible for a follow-up fix rather than silently drifting.
+    All 20 tests port their upstream ``thread.test.ts`` counterparts
+    1:1. The three behavior gaps that originally surfaced during the
+    port — ``UpdateTaskInput.id``, ``_enqueue_edit`` error propagation,
+    and synchronous chain registration under ``asyncio.gather`` — have
+    all been fixed in ``plan.py`` as part of this PR (#75).
     """
 
     # it("should post fallback text when adapter does not support plans")


### PR DESCRIPTION
## Summary

Ships `0.4.26.2` — a parity catch-up release for upstream `chat@4.26.0`. Bundles 8 merged PRs (`#64, #65, #66, #67, #73, #74, #75, #76`) plus small followup cleanups surfaced in post-merge review.

## In this PR

- **`pyproject.toml`**: `0.4.26.1` → `0.4.26.2`
- **`CHANGELOG.md`**: `## Unreleased` → `## 0.4.26.2 (2026-04-24)`; dropped a stray leftover merge-conflict marker; corrected `StreamingPlan.update_task` typo to `Plan.update_task` (StreamingPlan doesn't implement it)
- **`tests/test_thread_faithful.py`**: `TestPostWithPlan` docstring said the 3 Plan divergences (`UpdateTaskInput.id` / error propagation / FIFO ordering) were "unsupported/skipped" — they were actually fixed in #75. Rewrote the docstring.
- **`src/chat_sdk/adapters/slack/adapter.py`**: kept `asyncio.ensure_future` with an inline comment explaining why — `create_task` fails pyrefly because the `ChatInstance` Protocol types `process_options_load` as `Awaitable`, not `Coroutine`.

## Release highlights

- **`Thread.get_participants()`** (#54) — upstream-parity port
- **`onOptionsLoad` + Slack `block_suggestion`** (#50) — external-select dispatch
- **`rehydrateAttachment` hook + SSRF guards** (#52) — 5-adapter implementations with per-adapter URL allowlists
- **`StreamingPlan` + options** (#56) — adds `kind=='stream'` branch (options were silently dropped)
- **`IoRedisStateAdapter`** (#71) — TS/Python Redis interop
- **Teams cert config shape** (#58) — parity with upstream's deprecated-throws stub
- **20 `[post with Plan]` + 6 `[Streaming]` test ports** (#55, #56) + 3 Plan divergence fixes
- **Async `time.sleep` hygiene sweep** across 3 state test files

**Fidelity**: all `[getParticipants]` / `[thread]` / `[Options Load]` / `[post with Plan]` / `[Streaming]` / `[concurrency: queue attachment rehydration]` gaps closed.

## Test plan
- [x] `uv run ruff check src/ tests/ scripts/` — clean
- [x] `uv run ruff format --check src/ tests/ scripts/` — clean
- [x] `uv run pyrefly check` — 0 errors
- [x] `uv run python scripts/audit_test_quality.py` — 0 hard failures
- [x] `uv run pytest tests/ -q` — 3631 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)