### PR TITLE
feat(adapters): log init for gchat + github, include registered adapters in not-found error

### DIFF
--- a/src/chat_sdk/adapters/github/adapter.py
+++ b/src/chat_sdk/adapters/github/adapter.py
@@ -214,6 +214,8 @@ class GitHubAdapter:
             except Exception as error:
                 self._logger.warn("Could not fetch bot user ID", {"error": str(error)})
 
+        self._logger.info("GitHub adapter initialized")
+
     async def _get_http_session(self) -> Any:
         """Return the shared aiohttp session, creating it lazily if needed."""
         import aiohttp

--- a/src/chat_sdk/adapters/google_chat/adapter.py
+++ b/src/chat_sdk/adapters/google_chat/adapter.py
@@ -451,6 +451,8 @@ class GoogleChatAdapter:
                     {"botUserId": self._bot_user_id},
                 )
 
+        self._logger.info("Google Chat adapter initialized")
+
     async def disconnect(self) -> None:
         """Disconnect the adapter and close the shared HTTP session."""
         if self._http_session and not self._http_session.closed:

--- a/src/chat_sdk/chat.py
+++ b/src/chat_sdk/chat.py
@@ -1501,7 +1501,11 @@ class Chat:
             raise ChatError(f"Invalid channel ID: {channel_id}")
         adapter = self._adapters.get(adapter_name)
         if adapter is None:
-            raise ChatError(f'Adapter "{adapter_name}" not found for channel ID "{channel_id}"')
+            registered = sorted(self._adapters.keys())
+            raise ChatError(
+                f'Adapter "{adapter_name}" not found for channel ID "{channel_id}" '
+                f"(registered adapters: {registered})"
+            )
         return ChannelImpl(
             _ChannelImplConfigWithAdapter(
                 id=channel_id,
@@ -1559,7 +1563,11 @@ class Chat:
 
         adapter = self._adapters.get(adapter_name)
         if adapter is None:
-            raise ChatError(f'Adapter "{adapter_name}" not found for thread ID "{thread_id}"')
+            registered = sorted(self._adapters.keys())
+            raise ChatError(
+                f'Adapter "{adapter_name}" not found for thread ID "{thread_id}" '
+                f"(registered adapters: {registered})"
+            )
 
         # Defer to the adapter to derive channel_id as a secondary sanity
         # check — some platform-specific patterns can pass the structural


### PR DESCRIPTION
## Summary

- `GoogleChatAdapter.initialize()` now logs `Google Chat adapter initialized` matching the existing Slack/Teams pattern. Today only Slack and Teams emit per-adapter init lines; gchat and GitHub are silent, so operators can't see at a glance whether each adapter actually came up.
- `GitHubAdapter.initialize()` now logs `GitHub adapter initialized` unconditionally. The existing `GitHub auth completed` log only fires when `_auth_token` is set and the user-info fetch succeeds, so multi-tenant deployments (which use App credentials, not `_auth_token`) had no init signal.
- `Chat.channel()` and `Chat.thread()` not-found errors now append `(registered adapters: [...])` so operators can disambiguate "the adapter was never constructed in this process" from "constructed but the lookup name is wrong".

## Why now

Driven by a chinchill-api incident on 2026-05-19: a DBOS worker hit `Adapter "github" not found for thread ID "github:tony-chinchill-ai/test:issue:1"` with no other diagnostic context. With these changes the same error becomes `Adapter "github" not found for thread ID "github:..." (registered adapters: ['slack', 'teams'])`, immediately pointing at the GitHub-adapter construction path rather than the lookup path.

## Test plan

- [ ] `pytest` (no behavioral changes; only added log calls + error-message string).
- [ ] Manual: in a deployment that registers gchat + github, restart and confirm stderr contains both `[gchat] Google Chat adapter initialized` and `[github] GitHub adapter initialized` lines.
- [ ] Manual: trigger an `Adapter not found` error and confirm the registered-adapter list appears in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added initialization logs for GitHub and Google Chat adapters.
  * Enhanced error messages for invalid channel and thread IDs to display available adapters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chinchill-AI/chat-sdk-python/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->