### PR TITLE
build(python): bump Python floor from 3.10 to 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2
       - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ async def handle_mention(thread, message):
 | Feature | chat-sdk | Raw platform SDKs | BotFramework SDK |
 |---------|----------|--------------------|------------------|
 | Multi-platform from one codebase | 8 platforms | 1 per SDK | Teams + limited |
-| Async-native (Python 3.10+) | Yes | Varies | No |
+| Async-native (Python 3.12+) | Yes | Varies | No |
 | Cross-platform cards | Card model | Platform-specific | Adaptive Cards only |
 | Thread locking / dedup | Built-in | DIY | DIY |
 | State abstraction (mem/redis/pg) | Built-in | DIY | DIY |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
 ]
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = []
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -26,8 +26,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Communications",
@@ -99,11 +97,19 @@ include = [
 asyncio_mode = "auto"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "SIM", "UP"]
+# Modernization of pre-3.12 patterns is deferred to follow-up PRs; the 3.12
+# floor bump itself doesn't rewrite call sites. Re-enable these as the
+# codebase is migrated.
+ignore = [
+    "UP017",  # datetime.timezone.utc → datetime.UTC (3.11+)
+    "UP040",  # TypeAlias → PEP 695 `type` keyword (3.12+)
+    "UP041",  # asyncio.TimeoutError → builtins TimeoutError (3.11+)
+]
 
 [dependency-groups]
 dev = [
@@ -132,7 +138,7 @@ project-excludes = ["**/__pycache__", "**/.pytest_cache"]
 disable-project-excludes-heuristics = true
 use-ignore-files = false
 
-python-version = "3.10"
+python-version = "3.12"
 python-platform = "linux"
 
 # Optional adapter deps that aren't in the default install. Treating them as


### PR DESCRIPTION
## Summary

Bumps the Python floor from 3.10 to 3.12 across packaging, lint, type checking, and CI test matrix. This unblocks the upcoming Teams adapter migration to `microsoft-teams-apps` (#93), which requires Python 3.12+. Tracks the Python 3.12 sync wave (#98).

Consumer compatibility: our primary consumer **chinchill-api already runs on Python 3.12**, so no downstream impact — this was approved by the team.

## Changes

- `pyproject.toml`:
  - `requires-python = ">=3.12"` (was `>=3.10`)
  - `[tool.ruff] target-version = "py312"` (was `py310`)
  - `[tool.pyrefly] python-version = "3.12"` (was `3.10`)
  - Dropped `Programming Language :: Python :: 3.10` and `:: 3.11` classifiers
- `.github/workflows/test.yml`: matrix now `["3.12", "3.13"]` (was `["3.10", "3.11", "3.12", "3.13"]`)
- `README.md`: "Async-native (Python 3.10+)" → "3.12+" in feature comparison table

## Intentionally out of scope

Bumping `ruff target-version` to `py312` surfaces new modernization findings (107 total): `UP017` (`datetime.timezone.utc` → `datetime.UTC`), `UP040` (PEP 695 `type` keyword), `UP041` (`asyncio.TimeoutError` → builtin). These are **explicitly ignored in `[tool.ruff.lint]`** because this PR is the floor bump only, not a modernization sweep. The ignores are commented to make re-enabling deliberate; modernization can land incrementally as future PRs touch the relevant code.

The `scripts/fidelity_baseline.json` and `lint.yml` upstream-clone tag are untouched — that's a separate axis (upstream parity, not Python floor).

## Test plan

- [x] `uv sync --group dev` succeeds on Python 3.12.3
- [x] `uv run ruff check src/ tests/ scripts/` — All checks passed
- [x] `uv run ruff format --check src/ tests/ scripts/` — 197 files already formatted
- [x] `uv run python scripts/audit_test_quality.py` — 0 hard failures (39 pre-existing duplicate warnings)
- [x] `uv run pytest tests/ --tb=short -q` — **4036 passed, 3 skipped** (matches expected state)
- [x] `uv run pyrefly check` — 0 errors, 101 suppressed
- [ ] CI on PR confirms tests pass on both 3.12 and 3.13

Closes #98 (sync wave Python part). Unblocks #93 (Teams SDK migration).

https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj)_