### PR TITLE
docs(contributing): refresh Python floor references for 3.12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing! This guide covers the essentials.
 ## Dev Environment Setup
 
 ```bash
-# Clone and install (requires Python 3.10+ and uv)
+# Clone and install (requires Python 3.12+ and uv)
 git clone https://github.com/Chinchill-AI/chat-sdk-python.git
 cd chat-sdk-python
 uv sync --group dev
@@ -120,7 +120,7 @@ Vercel Chat version. See [UPSTREAM_SYNC.md](docs/UPSTREAM_SYNC.md#version-mappin
 
 ### What NOT to do
 
-- Don't publish without CI green on all 4 Python versions (3.10-3.13)
+- Don't publish without CI green on both Python versions (3.12, 3.13)
 - Don't skip the fidelity check for test changes
 - Don't use alpha tags for *final* sync releases — alpha tags (`0.4.26a1`) are
   only for work-in-progress ports while syncing a new upstream version


### PR DESCRIPTION
## Summary

Tiny follow-up to #111 (Python 3.12 floor bump). The post-merge code review caught two stale "Python 3.10" mentions in `CONTRIBUTING.md` that the original PR missed:

- `CONTRIBUTING.md:8` — install instructions said "requires Python 3.10+"
- `CONTRIBUTING.md:123` — publish checklist said "all 4 Python versions (3.10-3.13)"

No code, no runtime impact. Docs hygiene only.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj)_