### PR TITLE
fix(slack): surface files_upload_v2 confirmation in SentMessage.raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.29a2 (2026-05-28)
+
+Python-only fix. No upstream version change.
+
+### Fixes
+
+- **Slack now surfaces `files_upload_v2` confirmation through `post()`** — `SlackAdapter._upload_files` already computed the list of Slack-confirmed file IDs but `post_message` discarded the return, and `ThreadImpl._create_sent_message` hardcoded `raw=None`, so the confirmation never reached `SentMessage.raw`. Slack was the only file-capable adapter to drop this; discord/telegram upload inline and expose the platform response naturally. `post_message` now augments `RawMessage.raw` with `"uploaded_file_ids"` on every return path that can carry files (file-only, card, table, text), and `ThreadImpl._create_sent_message` accepts and propagates the adapter's `raw` into `SentMessage.raw`. `None` means no upload occurred; an empty list signals Slack confirmed zero attachments. The `raw` payload is augmented, not replaced, so existing consumers are unaffected. Unblocks chinchill gating UX on actual delivery success. An upstream `vercel/chat` issue is filed in parallel for convergence.
+
+### Test quality
+
+- Added 4 tests: three in `tests/test_slack_api.py` (file-only, text+files, and text-only-no-augment paths) and one end-to-end `tests/test_thread_faithful.py` test verifying `post()` propagates `RawMessage.raw` to `SentMessage.raw`.
+
 ## 0.4.29a1 (2026-05-28)
 
 Alpha sync starter for upstream `4.29.0` (`vercel/chat` release commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-sdk"
-version = "0.4.29a1"
+version = "0.4.29a2"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
 keywords = [
     "chat",

--- a/src/chat_sdk/adapters/slack/adapter.py
+++ b/src/chat_sdk/adapters/slack/adapter.py
@@ -3389,10 +3389,16 @@ class SlackAdapter:
         try:
             client = self._get_client()
 
-            # Check for files to upload
+            # Check for files to upload. ``files_upload_v2`` returns the
+            # Slack-confirmed file IDs; we surface them on ``RawMessage.raw``
+            # so consumers can gate on actual delivery (parity with
+            # discord/telegram, which upload inline and expose the platform
+            # response naturally). ``None`` means no upload happened; an empty
+            # list means Slack confirmed zero attachments (a real signal).
+            uploaded_file_ids: list[str] | None = None
             files = extract_files(message)
             if files:
-                await self._upload_files(files, channel, thread_ts or None)
+                uploaded_file_ids = await self._upload_files(files, channel, thread_ts or None)
                 has_text = (
                     isinstance(message, str)
                     or (hasattr(message, "raw") and getattr(message, "raw", None))
@@ -3404,7 +3410,7 @@ class SlackAdapter:
                     return RawMessage(
                         id=f"file-{int(time.time() * 1000)}",
                         thread_id=thread_id,
-                        raw={"files": files},
+                        raw=self._augment_raw_with_uploads({"files": files}, uploaded_file_ids),
                     )
 
             card = extract_card(message)
@@ -3426,7 +3432,10 @@ class SlackAdapter:
                 return RawMessage(
                     id=result.get("ts", ""),
                     thread_id=thread_id,
-                    raw=result.data if hasattr(result, "data") else result,
+                    raw=self._augment_raw_with_uploads(
+                        result.data if hasattr(result, "data") else result,
+                        uploaded_file_ids,
+                    ),
                 )
 
             # Table blocks
@@ -3443,7 +3452,10 @@ class SlackAdapter:
                 return RawMessage(
                     id=result.get("ts", ""),
                     thread_id=thread_id,
-                    raw=result.data if hasattr(result, "data") else result,
+                    raw=self._augment_raw_with_uploads(
+                        result.data if hasattr(result, "data") else result,
+                        uploaded_file_ids,
+                    ),
                 )
 
             # Regular text
@@ -3462,10 +3474,28 @@ class SlackAdapter:
             return RawMessage(
                 id=result.get("ts", ""),
                 thread_id=thread_id,
-                raw=result.data if hasattr(result, "data") else result,
+                raw=self._augment_raw_with_uploads(
+                    result.data if hasattr(result, "data") else result,
+                    uploaded_file_ids,
+                ),
             )
         except Exception as error:
             self._handle_slack_error(error)
+
+    @staticmethod
+    def _augment_raw_with_uploads(raw: Any, uploaded_file_ids: list[str] | None) -> Any:
+        """Add Slack-confirmed file IDs to a ``RawMessage.raw`` payload.
+
+        Returns ``raw`` unchanged when no upload occurred (``uploaded_file_ids``
+        is ``None``). Otherwise returns a NEW dict that merges the existing raw
+        (Slack never returns an ``uploaded_file_ids`` key, so this is additive
+        and non-breaking) with the confirmed IDs. An empty list is preserved —
+        it signals that Slack confirmed zero attachments.
+        """
+        if uploaded_file_ids is None:
+            return raw
+        base = raw if isinstance(raw, dict) else {}
+        return {**base, "uploaded_file_ids": uploaded_file_ids}
 
     async def edit_message(
         self,

--- a/src/chat_sdk/chat.py
+++ b/src/chat_sdk/chat.py
@@ -2483,7 +2483,13 @@ class _MessageHistoryCache:
 
     async def append(self, thread_id: str, message: Message) -> None:
         key = f"msg-history:{thread_id}"
+        # Serialize with raw nulled out to save storage (matches
+        # MessageHistoryCache.append in message_history.py). Without this,
+        # SentMessage.raw — now populated post-#117 with platform payloads
+        # like Slack team_id/user_id, Discord guild IDs — would persist to
+        # the state adapter on every reply, inflating storage and PII surface.
         data = message.to_json()
+        data["raw"] = None
         await self._state.append_to_list(key, data, max_length=self._max_messages, ttl_ms=self._ttl_ms)
 
     async def get_messages(self, thread_id: str, limit: int | None = None) -> list[Message]:

--- a/src/chat_sdk/thread.py
+++ b/src/chat_sdk/thread.py
@@ -566,7 +566,7 @@ class ThreadImpl:
 
         postable: AdapterPostableMessage = message  # type: ignore[assignment]
         raw_msg = await self.adapter.post_message(self._id, postable)
-        result = self._create_sent_message(raw_msg.id, postable, raw_msg.thread_id)
+        result = self._create_sent_message(raw_msg.id, postable, raw_msg.thread_id, raw=raw_msg.raw)
 
         if self._message_history is not None:
             await self._message_history.append(self._id, _to_message(result))
@@ -1122,6 +1122,7 @@ class ThreadImpl:
         message_id: str,
         postable: AdapterPostableMessage,
         thread_id_override: str | None = None,
+        raw: Any = None,
     ) -> SentMessage:
         adapter = self.adapter
         thread_id = thread_id_override or self._id
@@ -1160,7 +1161,7 @@ class ThreadImpl:
             ),
             attachments=attachments,
             links=[],
-            raw=None,
+            raw=raw,
             _edit=_edit,
             _delete=_delete,
             _add_reaction=_add_reaction,

--- a/tests/test_slack_api.py
+++ b/tests/test_slack_api.py
@@ -237,6 +237,63 @@ class TestPostMessage:
         assert len(client.get_calls("chat_postMessage")) == chat_post_calls_before
 
     @pytest.mark.asyncio
+    async def test_file_only_post_surfaces_confirmed_upload_ids(self):
+        """File-only post exposes Slack-confirmed file IDs on ``RawMessage.raw``."""
+        adapter, client, _ = await _init_adapter()
+        client.set_response(
+            "files_upload_v2",
+            {"ok": True, "files": [{"files": [{"id": "F1"}, {"id": "F2"}]}]},
+        )
+
+        from chat_sdk.types import FileUpload, PostableMarkdown
+
+        msg = PostableMarkdown(
+            markdown="",
+            files=[FileUpload(data=b"hello", filename="test.txt")],
+        )
+        result = await adapter.post_message("slack:C123:1234567890.000000", msg)
+
+        assert isinstance(result.raw, dict)
+        assert result.raw["uploaded_file_ids"] == ["F1", "F2"]
+        # The original raw payload is preserved (augment, don't replace).
+        assert "files" in result.raw
+
+    @pytest.mark.asyncio
+    async def test_text_with_files_surfaces_confirmed_upload_ids(self):
+        """Text + files post augments the chat_postMessage raw with confirmed IDs."""
+        adapter, client, _ = await _init_adapter()
+        client.set_response("chat_postMessage", {"ok": True, "ts": "1234567890.222222"})
+        client.set_response(
+            "files_upload_v2",
+            {"ok": True, "files": [{"files": [{"id": "F9"}]}]},
+        )
+
+        from chat_sdk.types import FileUpload, PostableMarkdown
+
+        msg = PostableMarkdown(
+            markdown="here is the report",
+            files=[FileUpload(data=b"hello", filename="report.txt")],
+        )
+        result = await adapter.post_message("slack:C123:1234567890.000000", msg)
+
+        assert result.id == "1234567890.222222"
+        assert isinstance(result.raw, dict)
+        assert result.raw["uploaded_file_ids"] == ["F9"]
+        # The Slack chat_postMessage response is preserved alongside the IDs.
+        assert result.raw["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_text_only_post_does_not_add_uploaded_file_ids(self):
+        """Posts without files leave ``raw`` unaugmented (no ``uploaded_file_ids`` key)."""
+        adapter, client, _ = await _init_adapter()
+        client.set_response("chat_postMessage", {"ok": True, "ts": "1234567890.333333"})
+
+        result = await adapter.post_message("slack:C123:1234567890.000000", "plain text")
+
+        assert isinstance(result.raw, dict)
+        assert "uploaded_file_ids" not in result.raw
+
+    @pytest.mark.asyncio
     async def test_file_upload_uses_channel_kwarg_not_channel_id(self):
         """Regression: slack-sdk's files_upload_v2 takes ``channel=``, not ``channel_id=``.
 

--- a/tests/test_thread_faithful.py
+++ b/tests/test_thread_faithful.py
@@ -260,6 +260,29 @@ class TestPostWithDifferentMessageFormats:
         result = await thread.post("Hello")
         assert result.thread_id == "slack:C123:new-thread-id"
 
+    # it("should propagate adapter RawMessage.raw onto SentMessage.raw")
+    @pytest.mark.asyncio
+    async def test_should_propagate_adapter_raw_onto_sent_message(self):
+        """post() must carry the adapter's RawMessage.raw through to
+        SentMessage.raw so consumers can read platform confirmation data
+        (e.g. Slack's ``uploaded_file_ids``)."""
+        adapter = create_mock_adapter()
+        state = create_mock_state()
+
+        async def custom_post(thread_id: str, message: Any) -> RawMessage:
+            return RawMessage(
+                id="msg-3",
+                thread_id=thread_id,
+                raw={"ok": True, "uploaded_file_ids": ["F1", "F2"]},
+            )
+
+        adapter.post_message = custom_post  # type: ignore[assignment]
+        thread = _make_thread(adapter, state)
+        result = await thread.post(PostableMarkdown(markdown="report", files=[]))
+
+        assert isinstance(result.raw, dict)
+        assert result.raw["uploaded_file_ids"] == ["F1", "F2"]
+
 
 # ===========================================================================
 # Streaming


### PR DESCRIPTION
## Problem — consistency gap

Slack is the only file-capable adapter that discards upload confirmation. `SlackAdapter._upload_files` calls `files_upload_v2` separately and already computes the list of Slack-confirmed file IDs, but `post_message` threw that return away, and `ThreadImpl._create_sent_message` hardcoded `raw=None` — so the confirmation never reached the `SentMessage` returned to callers.

discord and telegram don't have this gap: they upload inline, so their `RawMessage.raw` is the real platform response and flows through naturally. `SentMessage` already has a `raw` field; it was simply never populated on the `post()` path.

## Changes

**`src/chat_sdk/adapters/slack/adapter.py` — `post_message`:**
- Capture `_upload_files`' return (`uploaded_file_ids`).
- New `_augment_raw_with_uploads` helper adds an `"uploaded_file_ids"` key to `RawMessage.raw` on every return path that can carry files (file-only early return, card, table, text). The Slack response dict is augmented, never replaced — Slack never returns that key, so it's additive and non-breaking.
- `None` = no upload occurred; an empty list = Slack confirmed zero attachments (a real signal, preserved by guarding on `is not None`).

**`src/chat_sdk/thread.py`:**
- `_create_sent_message` gains a `raw: Any = None` parameter and sets `raw=raw` on the returned `SentMessage` (was hardcoded `None`).
- The `post()` call site passes `raw_msg.raw` through. Platform-agnostic — discord/telegram real platform responses now flow through to `SentMessage.raw` too, which is the intended use of the field.

## Why now

Unblocks a chinchill consumer that needs to gate UX on **actual** Slack delivery success (how many files Slack confirmed attaching), not just how many were requested.

An upstream `vercel/chat` issue is being filed in parallel for convergence (same gap exists in `packages/adapter-slack/src/index.ts`).

## Test plan

- `uv run pytest tests/ -q` → **4046 passed, 3 skipped** (was ~4042; +4 new).
- New tests (verified load-bearing — each fails when its corresponding change is reverted):
  - `tests/test_slack_api.py`: file-only post surfaces confirmed IDs; text+files augments the `chat_postMessage` raw; text-only does **not** add the key.
  - `tests/test_thread_faithful.py`: end-to-end `post()` propagates `RawMessage.raw` → `SentMessage.raw`.
- `uv run ruff format` + `uv run ruff check` clean.
- Version bumped `0.4.29a1` → `0.4.29a2`; CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * v0.4.29a2 released (2026-05-28)

* **Bug Fixes**
  * Slack file-upload confirmations are now surfaced in post responses, with confirmed file IDs captured and included.
  * Adapter raw payload data is propagated through to sent messages, preserving platform metadata for consumers.

* **Tests**
  * Added tests covering file-upload scenarios and message metadata propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chinchill-AI/chat-sdk-python/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->