### PR TITLE
feat(telegram): video_note extraction + typed attachment uploads (vercel/chat#457, #485)

### DIFF
--- a/src/chat_sdk/adapters/telegram/adapter.py
+++ b/src/chat_sdk/adapters/telegram/adapter.py
@@ -48,7 +48,11 @@ from chat_sdk.adapters.telegram.types import (
 from chat_sdk.emoji import convert_emoji_placeholders, emoji_to_unicode, get_emoji
 from chat_sdk.errors import ChatNotImplementedError
 from chat_sdk.logger import ConsoleLogger, Logger
-from chat_sdk.shared.adapter_utils import extract_card, extract_files
+from chat_sdk.shared.adapter_utils import (
+    extract_card,
+    extract_files,
+    extract_postable_attachments,
+)
 from chat_sdk.shared.card_utils import card_to_fallback_text
 from chat_sdk.shared.errors import (
     AdapterPermissionError,
@@ -90,6 +94,14 @@ TELEGRAM_SECRET_TOKEN_HEADER = "x-telegram-bot-api-secret-token"  # pragma: allo
 MESSAGE_ID_PATTERN = re.compile(r"^([^:]+):(\d+)$")
 TELEGRAM_MARKDOWN_PARSE_MODE = "MarkdownV2"
 MESSAGE_SEQUENCE_PATTERN = re.compile(r":(\d+)$")
+# Map a normalized Attachment.type to the Telegram Bot API media method and
+# its multipart form field. Port of upstream ATTACHMENT_UPLOADS (vercel/chat#485).
+ATTACHMENT_UPLOADS: dict[str, dict[str, str]] = {
+    "audio": {"field": "audio", "method": "sendAudio"},
+    "file": {"field": "document", "method": "sendDocument"},
+    "image": {"field": "photo", "method": "sendPhoto"},
+    "video": {"field": "video", "method": "sendVideo"},
+}
 LEADING_AT_PATTERN = re.compile(r"^@+")
 EMOJI_PLACEHOLDER_PATTERN = re.compile(r"^\{\{emoji:([a-z0-9_]+)\}\}$", re.IGNORECASE)
 EMOJI_NAME_PATTERN = re.compile(r"^[a-z0-9_+-]+$", re.IGNORECASE)
@@ -1208,6 +1220,19 @@ class TelegramAdapter:
                 "Telegram adapter supports a single file upload per message",
             )
 
+        attachments = extract_postable_attachments(message)
+        if len(attachments) > 1:
+            raise ValidationError(
+                "telegram",
+                "Telegram adapter supports a single attachment upload per message",
+            )
+
+        if files and attachments:
+            raise ValidationError(
+                "telegram",
+                "Telegram adapter does not support mixing file uploads and attachments in one message",
+            )
+
         raw_message: TelegramMessage
 
         if len(files) == 1:
@@ -1215,6 +1240,17 @@ class TelegramAdapter:
             if not file:
                 raise ValidationError("telegram", "File upload payload is empty")
             raw_message = await self.send_document(parsed_thread, file, text, reply_markup, parse_mode)
+        elif len(attachments) == 1:
+            attachment = attachments[0]
+            if not attachment:
+                raise ValidationError("telegram", "Attachment upload payload is empty")
+            raw_message = await self.send_attachment(
+                parsed_thread,
+                attachment,
+                text,
+                reply_markup,
+                parse_mode,
+            )
         else:
             if not text.strip():
                 raise ValidationError("telegram", "Message text cannot be empty")
@@ -1711,6 +1747,22 @@ class TelegramAdapter:
                 )
             )
 
+        # Round video messages (video_note) are a distinct Telegram field
+        # from `video`. Port of vercel/chat#457: extract them as a "video"
+        # attachment with width/height set to the clip's `length`.
+        video_note = raw.get("video_note")
+        if video_note:
+            length = video_note.get("length")
+            attachments.append(
+                self.create_attachment(
+                    "video",
+                    video_note["file_id"],
+                    size=video_note.get("file_size"),
+                    width=length,
+                    height=length,
+                )
+            )
+
         return attachments
 
     def create_attachment(
@@ -1831,6 +1883,93 @@ class TelegramAdapter:
             form_data.add_field("reply_markup", json.dumps(reply_markup))
 
         return await self.telegram_fetch("sendDocument", form_data)
+
+    async def send_attachment(
+        self,
+        thread: TelegramThreadId,
+        attachment: Attachment,
+        text: str,
+        reply_markup: TelegramInlineKeyboardMarkup | None = None,
+        parse_mode: str | None = None,
+    ) -> TelegramMessage:
+        """Send a typed attachment using the Telegram media method for its type.
+
+        Port of upstream ``sendAttachment`` (vercel/chat#485). Selects
+        ``sendPhoto``/``sendAudio``/``sendVideo``/``sendDocument`` based on
+        :data:`ATTACHMENT_UPLOADS`. Binary payloads (``data`` or ``fetch_data``)
+        are sent as multipart uploads; URL-only attachments are passed through
+        as a Telegram URL field (must be a public URL Telegram can fetch).
+        """
+        import aiohttp
+
+        upload = ATTACHMENT_UPLOADS[attachment.type]
+
+        data = attachment.data
+        if data is None and attachment.fetch_data is not None:
+            data = await attachment.fetch_data()
+
+        if data is None and not attachment.url:
+            raise ValidationError(
+                "telegram",
+                f"Attachment data or URL required for {attachment.type}",
+            )
+
+        if data is None:
+            payload: dict[str, Any] = {
+                "chat_id": thread.chat_id,
+                upload["field"]: attachment.url,
+            }
+
+            if isinstance(thread.message_thread_id, int):
+                payload["message_thread_id"] = thread.message_thread_id
+
+            if text.strip():
+                payload["caption"] = self.truncate_caption(text, parse_mode)
+                if parse_mode:
+                    payload["parse_mode"] = parse_mode
+
+            if attachment.type == "video":
+                if isinstance(attachment.width, int):
+                    payload["width"] = attachment.width
+                if isinstance(attachment.height, int):
+                    payload["height"] = attachment.height
+
+            if reply_markup:
+                payload["reply_markup"] = reply_markup
+
+            return await self.telegram_fetch(upload["method"], payload)
+
+        if isinstance(data, memoryview) or not isinstance(data, bytes):
+            data = bytes(data)
+
+        form_data = aiohttp.FormData()
+        form_data.add_field("chat_id", thread.chat_id)
+
+        if isinstance(thread.message_thread_id, int):
+            form_data.add_field("message_thread_id", str(thread.message_thread_id))
+
+        if text.strip():
+            form_data.add_field("caption", self.truncate_caption(text, parse_mode))
+            if parse_mode:
+                form_data.add_field("parse_mode", parse_mode)
+
+        if attachment.type == "video":
+            if isinstance(attachment.width, int):
+                form_data.add_field("width", str(attachment.width))
+            if isinstance(attachment.height, int):
+                form_data.add_field("height", str(attachment.height))
+
+        form_data.add_field(
+            upload["field"],
+            data,
+            filename=attachment.name or "attachment",
+            content_type=attachment.mime_type or "application/octet-stream",
+        )
+
+        if reply_markup:
+            form_data.add_field("reply_markup", json.dumps(reply_markup))
+
+        return await self.telegram_fetch(upload["method"], form_data)
 
     # -- Message caching -----------------------------------------------------
 

--- a/src/chat_sdk/adapters/telegram/adapter.py
+++ b/src/chat_sdk/adapters/telegram/adapter.py
@@ -1962,8 +1962,8 @@ class TelegramAdapter:
         form_data.add_field(
             upload["field"],
             data,
-            filename=attachment.name or "attachment",
-            content_type=attachment.mime_type or "application/octet-stream",
+            filename=attachment.name if attachment.name is not None else "attachment",
+            content_type=attachment.mime_type if attachment.mime_type is not None else "application/octet-stream",
         )
 
         if reply_markup:

--- a/src/chat_sdk/adapters/telegram/adapter.py
+++ b/src/chat_sdk/adapters/telegram/adapter.py
@@ -1902,6 +1902,11 @@ class TelegramAdapter:
         """
         import aiohttp
 
+        if attachment.type not in ATTACHMENT_UPLOADS:
+            raise ValidationError(
+                "telegram",
+                f"Unsupported attachment type: {attachment.type}. Supported types: {', '.join(ATTACHMENT_UPLOADS)}",
+            )
         upload = ATTACHMENT_UPLOADS[attachment.type]
 
         data = attachment.data

--- a/src/chat_sdk/adapters/telegram/types.py
+++ b/src/chat_sdk/adapters/telegram/types.py
@@ -208,6 +208,17 @@ class TelegramVideoFile(TypedDict, total=False):
     file_name: str
 
 
+class TelegramVideoNoteFile(TypedDict, total=False):
+    """Telegram video note (round video message) with extra metadata."""
+
+    file_id: str  # required
+    file_path: str
+    file_size: int
+    file_unique_id: str
+    length: int
+    duration: int
+
+
 class TelegramVoiceFile(TypedDict, total=False):
     """Telegram voice file with extra metadata."""
 
@@ -249,6 +260,7 @@ class TelegramMessage(TypedDict, total=False):
     sticker: TelegramStickerFile
     text: str
     video: TelegramVideoFile
+    video_note: TelegramVideoNoteFile
     voice: TelegramVoiceFile
 
 

--- a/src/chat_sdk/shared/__init__.py
+++ b/src/chat_sdk/shared/__init__.py
@@ -1,6 +1,10 @@
 """Shared utilities for chat SDK adapters."""
 
-from chat_sdk.shared.adapter_utils import extract_card, extract_files
+from chat_sdk.shared.adapter_utils import (
+    extract_card,
+    extract_files,
+    extract_postable_attachments,
+)
 from chat_sdk.shared.base_format_converter import BaseFormatConverter
 from chat_sdk.shared.buffer_utils import (
     buffer_to_data_uri,
@@ -67,6 +71,7 @@ __all__ = [
     "escape_table_cell",
     "extract_card",
     "extract_files",
+    "extract_postable_attachments",
     "map_button_style",
     "mock_logger",
     "parse_markdown",

--- a/src/chat_sdk/shared/adapter_utils.py
+++ b/src/chat_sdk/shared/adapter_utils.py
@@ -37,8 +37,10 @@ def extract_postable_attachments(message: AdapterPostableMessage) -> list[Attach
     """
     if isinstance(message, str):
         return []
-    if hasattr(message, "attachments") and message.attachments:  # type: ignore[union-attr]
-        return message.attachments  # type: ignore[union-attr]
+    if hasattr(message, "attachments"):
+        attachments = message.attachments  # type: ignore[union-attr]
+        return attachments if attachments is not None else []
     if isinstance(message, dict) and "attachments" in message:
-        return message.get("attachments") or []
+        attachments = message.get("attachments")
+        return attachments if attachments is not None else []
     return []

--- a/src/chat_sdk/shared/adapter_utils.py
+++ b/src/chat_sdk/shared/adapter_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from chat_sdk.cards import CardElement, is_card_element
-from chat_sdk.types import AdapterPostableMessage, FileUpload
+from chat_sdk.types import AdapterPostableMessage, Attachment, FileUpload
 
 
 def extract_card(message: AdapterPostableMessage) -> CardElement | None:
@@ -25,4 +25,20 @@ def extract_files(message: AdapterPostableMessage) -> list[FileUpload]:
         return message.files  # type: ignore[union-attr]
     if isinstance(message, dict) and "files" in message:
         return message.get("files") or []
+    return []
+
+
+def extract_postable_attachments(message: AdapterPostableMessage) -> list[Attachment]:
+    """Extract a typed Attachment array from an AdapterPostableMessage.
+
+    Port of upstream ``extractPostableAttachments`` (vercel/chat#485). Returns
+    the message's ``attachments`` array when present, else an empty list.
+    Non-object messages (plain strings, cards) yield an empty list.
+    """
+    if isinstance(message, str):
+        return []
+    if hasattr(message, "attachments") and message.attachments:  # type: ignore[union-attr]
+        return message.attachments  # type: ignore[union-attr]
+    if isinstance(message, dict) and "attachments" in message:
+        return message.get("attachments") or []
     return []

--- a/tests/test_shared_adapter_utils.py
+++ b/tests/test_shared_adapter_utils.py
@@ -1,0 +1,74 @@
+"""Tests for shared adapter utility functions.
+
+Port of packages/adapter-shared/src/adapter-utils.test.ts -- specifically the
+``extractPostableAttachments`` cases added in vercel/chat#485.
+"""
+
+from __future__ import annotations
+
+from chat_sdk.cards import Card
+from chat_sdk.shared.adapter_utils import extract_postable_attachments
+from chat_sdk.types import Attachment, PostableAst, PostableMarkdown, PostableRaw
+
+
+class TestExtractPostableAttachmentsPresent:
+    """Attachments present on the message are returned verbatim."""
+
+    def test_extracts_from_postable_raw(self):
+        attachments = [
+            Attachment(type="file", data=b"content1", name="file1.txt"),
+            Attachment(type="file", data=b"content2", name="file2.txt"),
+        ]
+        message = PostableRaw(raw="Text", attachments=attachments)
+        result = extract_postable_attachments(message)
+        assert result is attachments
+        assert len(result) == 2
+
+    def test_extracts_from_postable_markdown(self):
+        attachments = [
+            Attachment(type="image", data=b"image", name="image.png", mime_type="image/png"),
+        ]
+        message = PostableMarkdown(markdown="**Text**", attachments=attachments)
+        result = extract_postable_attachments(message)
+        assert result == attachments
+        assert result[0].mime_type == "image/png"
+
+    def test_extracts_from_postable_ast(self):
+        attachments = [Attachment(type="file", data=b"doc", name="doc.pdf")]
+        message = PostableAst(ast={"type": "root", "children": []}, attachments=attachments)
+        result = extract_postable_attachments(message)
+        assert result is attachments
+
+    def test_extracts_from_dict_message(self):
+        attachments = [Attachment(type="image", data=b"x")]
+        result = extract_postable_attachments({"raw": "Text", "attachments": attachments})
+        assert result == attachments
+
+
+class TestExtractPostableAttachmentsEmptyOrMissing:
+    """Empty or missing attachments yield an empty list."""
+
+    def test_empty_attachments_list(self):
+        assert extract_postable_attachments(PostableRaw(raw="Text", attachments=[])) == []
+
+    def test_none_attachments(self):
+        assert extract_postable_attachments(PostableRaw(raw="Text", attachments=None)) == []
+
+    def test_postable_raw_without_attachments(self):
+        assert extract_postable_attachments(PostableRaw(raw="Just text")) == []
+
+    def test_postable_markdown_without_attachments(self):
+        assert extract_postable_attachments(PostableMarkdown(markdown="**Bold**")) == []
+
+    def test_dict_without_attachments(self):
+        assert extract_postable_attachments({"raw": "Just text"}) == []
+
+
+class TestExtractPostableAttachmentsNonObject:
+    """Non-message inputs yield an empty list rather than raising."""
+
+    def test_plain_string(self):
+        assert extract_postable_attachments("Hello world") == []
+
+    def test_card_element(self):
+        assert extract_postable_attachments(Card(title="Test")) == []

--- a/tests/test_telegram_api.py
+++ b/tests/test_telegram_api.py
@@ -397,6 +397,32 @@ class TestPostMessageTypedAttachmentUploads:
 
         adapter.telegram_fetch.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_rejects_unsupported_attachment_type(self):
+        """An attachment.type not in ATTACHMENT_UPLOADS raises a clear ValidationError.
+
+        ``Attachment.type`` is a ``Literal``, but Python does not enforce it at
+        runtime, so an untyped/dynamic caller can supply an out-of-set value.
+        Without the guard the per-type dict lookup raises a bare ``KeyError``;
+        we surface a ``ValidationError`` naming the bad type and the supported
+        set instead. Load-bearing: reverting the guard makes this raise
+        ``KeyError`` (not ``ValidationError``) and the test fails.
+        """
+        adapter = _make_adapter()
+        _init_adapter(adapter)
+        adapter.telegram_fetch = AsyncMock(return_value=_make_telegram_message())
+
+        with pytest.raises(ValidationError, match="Unsupported attachment type: sticker"):
+            await adapter.post_message(
+                THREAD_ID,
+                PostableRaw(
+                    raw="",
+                    attachments=[Attachment(type="sticker", data=b"x")],  # type: ignore[arg-type]
+                ),
+            )
+
+        adapter.telegram_fetch.assert_not_called()
+
 
 # =============================================================================
 # Tests -- edit_message

--- a/tests/test_telegram_api.py
+++ b/tests/test_telegram_api.py
@@ -32,6 +32,7 @@ from chat_sdk.shared.errors import (
     AuthenticationError,
     ValidationError,
 )
+from chat_sdk.types import Attachment, FileUpload, PostableMarkdown, PostableRaw
 
 # =============================================================================
 # Helpers
@@ -162,6 +163,239 @@ class TestPostMessageParseMode:
 
         payload = adapter.telegram_fetch.call_args[0][1]
         assert payload.get("parse_mode") == "MarkdownV2"
+
+
+# =============================================================================
+# Tests -- typed attachment uploads (vercel/chat#485)
+# =============================================================================
+
+
+def _form_fields(form_data: Any) -> dict[str, Any]:
+    """Map a non-binary aiohttp.FormData field name -> string value."""
+    fields: dict[str, Any] = {}
+    for type_options, _headers, value in form_data._fields:
+        if not isinstance(value, (bytes, bytearray, memoryview)):
+            fields[type_options["name"]] = value
+    return fields
+
+
+def _form_binary_field(form_data: Any, name: str) -> tuple[Any, str | None, str | None]:
+    """Return (value, filename, content_type) for a binary FormData field."""
+    for type_options, headers, value in form_data._fields:
+        if type_options["name"] == name:
+            return value, type_options.get("filename"), headers.get("Content-Type")
+    raise AssertionError(f"FormData field {name!r} not found")
+
+
+class TestPostMessageTypedAttachmentUploads:
+    """post_message routes typed attachments to the per-type Telegram method."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("attachment_type", "field", "method", "mime_type", "name"),
+        [
+            ("image", "photo", "sendPhoto", "image/png", "image.png"),
+            ("audio", "audio", "sendAudio", "audio/mpeg", "track.mp3"),
+            ("video", "video", "sendVideo", "video/mp4", "clip.mp4"),
+            ("file", "document", "sendDocument", "application/pdf", "report.pdf"),
+        ],
+    )
+    async def test_typed_attachment_selects_method(
+        self,
+        attachment_type: str,
+        field: str,
+        method: str,
+        mime_type: str,
+        name: str,
+    ):
+        adapter = _make_adapter()
+        _init_adapter(adapter)
+        adapter.telegram_fetch = AsyncMock(return_value=_make_telegram_message())
+
+        await adapter.post_message(
+            THREAD_ID,
+            PostableMarkdown(
+                markdown="attached **media**",
+                attachments=[
+                    Attachment(
+                        type=attachment_type,  # type: ignore[arg-type]
+                        data=b"payload",
+                        mime_type=mime_type,
+                        name=name,
+                        width=1280 if attachment_type == "video" else None,
+                        height=720 if attachment_type == "video" else None,
+                    )
+                ],
+            ),
+        )
+
+        called_method = adapter.telegram_fetch.call_args[0][0]
+        form_data = adapter.telegram_fetch.call_args[0][1]
+        assert called_method == method
+
+        fields = _form_fields(form_data)
+        assert fields["chat_id"] == CHAT_ID
+        assert fields["caption"] == "attached *media*"
+        assert fields["parse_mode"] == "MarkdownV2"
+
+        value, filename, content_type = _form_binary_field(form_data, field)
+        assert value == b"payload"
+        assert filename == name
+        assert content_type == mime_type
+
+        if attachment_type == "video":
+            assert fields["width"] == "1280"
+            assert fields["height"] == "720"
+        else:
+            assert "width" not in fields
+            assert "height" not in fields
+
+    @pytest.mark.asyncio
+    async def test_attachment_loaded_through_fetch_data(self):
+        adapter = _make_adapter()
+        _init_adapter(adapter)
+        adapter.telegram_fetch = AsyncMock(return_value=_make_telegram_message())
+
+        fetch_data = AsyncMock(return_value=b"payload")
+
+        await adapter.post_message(
+            THREAD_ID,
+            PostableRaw(
+                raw="",
+                attachments=[
+                    Attachment(
+                        type="file",
+                        mime_type="application/pdf",
+                        name="report.pdf",
+                        fetch_data=fetch_data,
+                    )
+                ],
+            ),
+        )
+
+        fetch_data.assert_awaited_once()
+        method = adapter.telegram_fetch.call_args[0][0]
+        form_data = adapter.telegram_fetch.call_args[0][1]
+        assert method == "sendDocument"
+        fields = _form_fields(form_data)
+        # ``raw=""`` ships verbatim with no caption / parse_mode.
+        assert "caption" not in fields
+        assert "parse_mode" not in fields
+        value, _filename, _content_type = _form_binary_field(form_data, "document")
+        assert value == b"payload"
+
+    @pytest.mark.asyncio
+    async def test_url_only_attachment_uses_url_field(self):
+        adapter = _make_adapter()
+        _init_adapter(adapter)
+        adapter.telegram_fetch = AsyncMock(return_value=_make_telegram_message())
+
+        await adapter.post_message(
+            THREAD_ID,
+            PostableMarkdown(
+                markdown="public **image**",
+                attachments=[
+                    Attachment(
+                        type="image",
+                        mime_type="image/png",
+                        name="image.png",
+                        url="https://cdn.example.com/image.png",
+                    )
+                ],
+            ),
+        )
+
+        method = adapter.telegram_fetch.call_args[0][0]
+        payload = adapter.telegram_fetch.call_args[0][1]
+        assert method == "sendPhoto"
+        # URL-only attachments ship as a JSON dict, not multipart FormData.
+        assert isinstance(payload, dict)
+        assert payload["chat_id"] == CHAT_ID
+        assert payload["photo"] == "https://cdn.example.com/image.png"
+        assert payload["caption"] == "public *image*"
+        assert payload["parse_mode"] == "MarkdownV2"
+
+    @pytest.mark.asyncio
+    async def test_url_only_video_attachment_includes_dimensions(self):
+        # Edge case beyond the upstream URL test: video width/height ride
+        # along on the JSON URL path too.
+        adapter = _make_adapter()
+        _init_adapter(adapter)
+        adapter.telegram_fetch = AsyncMock(return_value=_make_telegram_message())
+
+        await adapter.post_message(
+            THREAD_ID,
+            PostableMarkdown(
+                markdown="clip",
+                attachments=[
+                    Attachment(
+                        type="video",
+                        url="https://cdn.example.com/clip.mp4",
+                        width=1280,
+                        height=720,
+                    )
+                ],
+            ),
+        )
+
+        method = adapter.telegram_fetch.call_args[0][0]
+        payload = adapter.telegram_fetch.call_args[0][1]
+        assert method == "sendVideo"
+        assert payload["video"] == "https://cdn.example.com/clip.mp4"
+        assert payload["width"] == 1280
+        assert payload["height"] == 720
+
+    @pytest.mark.asyncio
+    async def test_rejects_multiple_attachments(self):
+        adapter = _make_adapter()
+        _init_adapter(adapter)
+        adapter.telegram_fetch = AsyncMock(return_value=_make_telegram_message())
+
+        with pytest.raises(ValidationError, match="single attachment upload"):
+            await adapter.post_message(
+                THREAD_ID,
+                PostableRaw(
+                    raw="attachments",
+                    attachments=[
+                        Attachment(type="image", data=b"one"),
+                        Attachment(type="image", data=b"two"),
+                    ],
+                ),
+            )
+
+        adapter.telegram_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_mixed_files_and_attachments(self):
+        adapter = _make_adapter()
+        _init_adapter(adapter)
+        adapter.telegram_fetch = AsyncMock(return_value=_make_telegram_message())
+
+        with pytest.raises(ValidationError, match="mixing file uploads and attachments"):
+            await adapter.post_message(
+                THREAD_ID,
+                PostableRaw(
+                    raw="mixed",
+                    attachments=[Attachment(type="image", data=b"one")],
+                    files=[FileUpload(data=b"two", filename="two.txt")],
+                ),
+            )
+
+        adapter.telegram_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_attachment_without_data_or_url(self):
+        adapter = _make_adapter()
+        _init_adapter(adapter)
+        adapter.telegram_fetch = AsyncMock(return_value=_make_telegram_message())
+
+        with pytest.raises(ValidationError, match="Attachment data or URL required for image"):
+            await adapter.post_message(
+                THREAD_ID,
+                PostableRaw(raw="", attachments=[Attachment(type="image")]),
+            )
+
+        adapter.telegram_fetch.assert_not_called()
 
 
 # =============================================================================

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -319,6 +319,71 @@ class TestTelegramParseMessageAttachments:
         assert parsed.attachments[0].height == 1080
         assert parsed.attachments[0].mime_type == "video/mp4"
 
+    def test_video_note_attachment(self):
+        # Port of vercel/chat#457: round video messages (video_note) extract
+        # as a "video" attachment with width/height set to the clip's length.
+        adapter = _make_adapter()
+        msg = _sample_message(
+            text=None,
+            video_note={
+                "file_id": "vn1",
+                "file_unique_id": "uvn1",
+                "length": 240,
+                "duration": 10,
+                "file_size": 512000,
+            },
+        )
+        parsed = adapter.parse_message(msg)
+        assert len(parsed.attachments) == 1
+        attachment = parsed.attachments[0]
+        assert attachment.type == "video"
+        assert attachment.width == 240
+        assert attachment.height == 240
+        assert attachment.size == 512000
+
+    def test_video_note_attachment_stores_file_id(self):
+        # video_note must round-trip its file_id into fetch_metadata so the
+        # lazy download closure can be rebuilt after serialization.
+        adapter = _make_adapter()
+        msg = _sample_message(
+            text=None,
+            video_note={"file_id": "vn2", "file_unique_id": "uvn2", "length": 120},
+        )
+        parsed = adapter.parse_message(msg)
+        assert len(parsed.attachments) == 1
+        assert parsed.attachments[0].fetch_metadata == {"fileId": "vn2"}
+
+    def test_video_note_attachment_without_optional_fields(self):
+        # Edge case not covered upstream: video_note with no length and no
+        # file_size must still extract a video attachment without raising,
+        # leaving width/height/size as None.
+        adapter = _make_adapter()
+        msg = _sample_message(
+            text=None,
+            video_note={"file_id": "vn3", "file_unique_id": "uvn3"},
+        )
+        parsed = adapter.parse_message(msg)
+        assert len(parsed.attachments) == 1
+        attachment = parsed.attachments[0]
+        assert attachment.type == "video"
+        assert attachment.width is None
+        assert attachment.height is None
+        assert attachment.size is None
+
+    def test_video_note_attachment_zero_length(self):
+        # Edge case not covered upstream: a zero length must propagate as
+        # width/height == 0 (not be dropped by a truthiness check).
+        adapter = _make_adapter()
+        msg = _sample_message(
+            text=None,
+            video_note={"file_id": "vn4", "file_unique_id": "uvn4", "length": 0},
+        )
+        parsed = adapter.parse_message(msg)
+        assert len(parsed.attachments) == 1
+        attachment = parsed.attachments[0]
+        assert attachment.width == 0
+        assert attachment.height == 0
+
 
 # ---------------------------------------------------------------------------
 # applyTelegramEntities (complementary to existing tests)


### PR DESCRIPTION
Ports two upstream Telegram adapter changes from `chat@4.29.0`, bundled together since they touch the same file area (`src/chat_sdk/adapters/telegram/adapter.py`).

Tracking #98.

## #457 — `video_note` extraction (upstream `711babe`)

Round video messages arrive in the distinct `video_note` field and were silently dropped by `extract_attachments`. They now extract as a `"video"` attachment with `width`/`height` set to the clip's `length` and `size` from `file_size`, matching upstream's mapping. Added the `TelegramVideoNoteFile` type and the `video_note` field to `TelegramMessage`.

## #485 — typed attachment uploads (upstream `add2730`)

Adds typed handling for **outgoing** attachment uploads:

- `extract_postable_attachments()` added to `chat_sdk.shared.adapter_utils` (and re-exported) — port of upstream `extractPostableAttachments`.
- New `send_attachment()` path in `post_message`, selecting the correct Bot API method per attachment type via the `ATTACHMENT_UPLOADS` mapping.
- Validation matches upstream: at most one attachment per message; no mixing `files` + `attachments`; binary attachments require `data`/`fetch_data`, URL-only attachments require a public URL.

### Type → method mapping (`ATTACHMENT_UPLOADS`)

| `Attachment.type` | form field | Bot API method |
|---|---|---|
| `image` | `photo` | `sendPhoto` |
| `audio` | `audio` | `sendAudio` |
| `video` | `video` | `sendVideo` |
| `file` | `document` | `sendDocument` |

Binary payloads (`data` or `fetch_data`) ship as multipart `aiohttp.FormData`; URL-only attachments ship as a JSON payload with the URL in the type's field. `video` attachments include `width`/`height` (guarded by `isinstance(..., int)`, matching upstream `Number.isInteger`). Telegram has no outgoing `video_note` method, so (as upstream) round videos round-trip out as `sendVideo`.

## Notes / hazards

- **Hazard #1 (truthiness):** width/height use `isinstance(..., int)` and data resolution uses `is not None`, so `length == 0` and empty payloads are not silently dropped.
- **Hazard #10 (lazy deps):** `import aiohttp` kept function-local in `send_attachment`, consistent with `send_document`/`download_file`.
- Python's `parse_mode` is already `str | None` (None == upstream `"plain"`), so no `toBotApiParseMode` translation was needed.

## Tests

Ported upstream test cases plus edge cases upstream did not cover:

- `tests/test_telegram_webhook.py`: `video_note` extraction — with metadata, file_id round-trip into `fetch_metadata`, **missing optional fields**, and **zero `length`** (Python-only edge cases).
- `tests/test_telegram_api.py`: parametrized per-type method selection, `fetch_data` loading, URL-only path, **URL-only video dimensions** (Python-only edge case), and the three rejection paths (multiple attachments / mixed files+attachments / no data-or-url).
- `tests/test_shared_adapter_utils.py` (new): `extract_postable_attachments` cases ported from `adapter-shared/src/adapter-utils.test.ts`.

## Validation

- `ruff check` + `ruff format --check`: clean
- `audit_test_quality.py`: 0 hard failures
- `pytest tests/ -k telegram`: 322 passed
- Full suite: 4068 passed, 3 skipped (pre-existing)

## Upstream references

- vercel/chat#457 — `fix(adapter-telegram): handle video_note in extractAttachments` (`711babe`)
- vercel/chat#485 — `feat(telegram): support typed attachment uploads` (`add2730`)

https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed attachment uploads for Telegram (photos, videos, audio, documents) with caption and sizing support.
  * Added support for Telegram video notes, converted to video attachments with derived dimensions.
* **Bug Fixes**
  * Validation to reject invalid or mixed attachment combinations.
* **Tests**
  * New tests covering attachment extraction, typed upload routing, URL vs multipart uploads, and video-note parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chinchill-AI/chat-sdk-python/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->