### PR TITLE
release: 0.4.27.1 — backport Slack files_upload_v2 confirmation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Python-only patch on the 0.4.27 line. No upstream version change; does NOT inclu
 ### Fixes
 
 - **Slack now surfaces `files_upload_v2` confirmation through `post()`** — `SlackAdapter._upload_files` already computed the list of Slack-confirmed file IDs but `post_message` discarded the return, and `ThreadImpl._create_sent_message` hardcoded `raw=None`, so the confirmation never reached `SentMessage.raw`. Slack was the only file-capable adapter to drop this; discord/telegram upload inline and expose the platform response naturally. `post_message` now augments `RawMessage.raw` with `"uploaded_file_ids"` on every return path that can carry files (file-only, card, table, text), and `ThreadImpl._create_sent_message` accepts and propagates the adapter's `raw` into `SentMessage.raw`. `None` means no upload occurred; an empty list signals Slack confirmed zero attachments. The `raw` payload is augmented, not replaced, so existing consumers are unaffected. Backported from #117 (which targets the 0.4.29 line). Unblocks chinchill gating UX on actual delivery success. Upstream convergence tracked in vercel/chat#564.
+- **`chat._MessageHistoryCache` now nulls `raw` before persisting to history** — mirror of the existing null-out in `message_history.MessageHistoryCache.append`. Without this, the platform payload that the above fix populates on `SentMessage.raw` (Slack `team_id`/`user_id`, Discord `guildId`, etc.) would persist on every reply to Redis/Postgres-backed state, inflating storage and PII surface. Caught by post-merge review of #117.
 
 ### Test quality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.27.1 (2026-05-29)
+
+Python-only patch on the 0.4.27 line. No upstream version change; does NOT include the 0.4.29 alpha sync work.
+
+### Fixes
+
+- **Slack now surfaces `files_upload_v2` confirmation through `post()`** — `SlackAdapter._upload_files` already computed the list of Slack-confirmed file IDs but `post_message` discarded the return, and `ThreadImpl._create_sent_message` hardcoded `raw=None`, so the confirmation never reached `SentMessage.raw`. Slack was the only file-capable adapter to drop this; discord/telegram upload inline and expose the platform response naturally. `post_message` now augments `RawMessage.raw` with `"uploaded_file_ids"` on every return path that can carry files (file-only, card, table, text), and `ThreadImpl._create_sent_message` accepts and propagates the adapter's `raw` into `SentMessage.raw`. `None` means no upload occurred; an empty list signals Slack confirmed zero attachments. The `raw` payload is augmented, not replaced, so existing consumers are unaffected. Backported from #117 (which targets the 0.4.29 line). Unblocks chinchill gating UX on actual delivery success. Upstream convergence tracked in vercel/chat#564.
+
+### Test quality
+
+- Added 4 tests: three in `tests/test_slack_api.py` (file-only, text+files, text-only-no-augment paths) and one end-to-end `tests/test_thread_faithful.py` test verifying `post()` propagates `RawMessage.raw` to `SentMessage.raw`.
+
 ## 0.4.27 (2026-05-28)
 
 Synced to upstream `vercel/chat@4.27.0` (release commit `f55378a`, Apr 30 2026). Highlights: Slack Socket Mode + dynamic bot-token resolver, Teams native DM streaming, `chat.get_user()` across all 8 adapters, Telegram MarkdownV2 rendering, and a sweep of adapter bug fixes. Sets `UPSTREAM_PARITY = "4.27.0"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-sdk"
-version = "0.4.27"
+version = "0.4.27.1"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
 keywords = [
     "chat",

--- a/src/chat_sdk/adapters/slack/adapter.py
+++ b/src/chat_sdk/adapters/slack/adapter.py
@@ -3389,10 +3389,16 @@ class SlackAdapter:
         try:
             client = self._get_client()
 
-            # Check for files to upload
+            # Check for files to upload. ``files_upload_v2`` returns the
+            # Slack-confirmed file IDs; we surface them on ``RawMessage.raw``
+            # so consumers can gate on actual delivery (parity with
+            # discord/telegram, which upload inline and expose the platform
+            # response naturally). ``None`` means no upload happened; an empty
+            # list means Slack confirmed zero attachments (a real signal).
+            uploaded_file_ids: list[str] | None = None
             files = extract_files(message)
             if files:
-                await self._upload_files(files, channel, thread_ts or None)
+                uploaded_file_ids = await self._upload_files(files, channel, thread_ts or None)
                 has_text = (
                     isinstance(message, str)
                     or (hasattr(message, "raw") and getattr(message, "raw", None))
@@ -3404,7 +3410,7 @@ class SlackAdapter:
                     return RawMessage(
                         id=f"file-{int(time.time() * 1000)}",
                         thread_id=thread_id,
-                        raw={"files": files},
+                        raw=self._augment_raw_with_uploads({"files": files}, uploaded_file_ids),
                     )
 
             card = extract_card(message)
@@ -3426,7 +3432,10 @@ class SlackAdapter:
                 return RawMessage(
                     id=result.get("ts", ""),
                     thread_id=thread_id,
-                    raw=result.data if hasattr(result, "data") else result,
+                    raw=self._augment_raw_with_uploads(
+                        result.data if hasattr(result, "data") else result,
+                        uploaded_file_ids,
+                    ),
                 )
 
             # Table blocks
@@ -3443,7 +3452,10 @@ class SlackAdapter:
                 return RawMessage(
                     id=result.get("ts", ""),
                     thread_id=thread_id,
-                    raw=result.data if hasattr(result, "data") else result,
+                    raw=self._augment_raw_with_uploads(
+                        result.data if hasattr(result, "data") else result,
+                        uploaded_file_ids,
+                    ),
                 )
 
             # Regular text
@@ -3462,10 +3474,28 @@ class SlackAdapter:
             return RawMessage(
                 id=result.get("ts", ""),
                 thread_id=thread_id,
-                raw=result.data if hasattr(result, "data") else result,
+                raw=self._augment_raw_with_uploads(
+                    result.data if hasattr(result, "data") else result,
+                    uploaded_file_ids,
+                ),
             )
         except Exception as error:
             self._handle_slack_error(error)
+
+    @staticmethod
+    def _augment_raw_with_uploads(raw: Any, uploaded_file_ids: list[str] | None) -> Any:
+        """Add Slack-confirmed file IDs to a ``RawMessage.raw`` payload.
+
+        Returns ``raw`` unchanged when no upload occurred (``uploaded_file_ids``
+        is ``None``). Otherwise returns a NEW dict that merges the existing raw
+        (Slack never returns an ``uploaded_file_ids`` key, so this is additive
+        and non-breaking) with the confirmed IDs. An empty list is preserved —
+        it signals that Slack confirmed zero attachments.
+        """
+        if uploaded_file_ids is None:
+            return raw
+        base = raw if isinstance(raw, dict) else {}
+        return {**base, "uploaded_file_ids": uploaded_file_ids}
 
     async def edit_message(
         self,

--- a/src/chat_sdk/chat.py
+++ b/src/chat_sdk/chat.py
@@ -2454,7 +2454,13 @@ class _MessageHistoryCache:
 
     async def append(self, thread_id: str, message: Message) -> None:
         key = f"msg-history:{thread_id}"
+        # Serialize with raw nulled out to save storage (matches
+        # MessageHistoryCache.append in message_history.py). Without this,
+        # SentMessage.raw — now populated post-#117 with platform payloads
+        # like Slack team_id/user_id, Discord guild IDs — would persist to
+        # the state adapter on every reply, inflating storage and PII surface.
         data = message.to_json()
+        data["raw"] = None
         await self._state.append_to_list(key, data, max_length=self._max_messages, ttl_ms=self._ttl_ms)
 
     async def get_messages(self, thread_id: str, limit: int | None = None) -> list[Message]:

--- a/src/chat_sdk/thread.py
+++ b/src/chat_sdk/thread.py
@@ -566,7 +566,7 @@ class ThreadImpl:
 
         postable: AdapterPostableMessage = message  # type: ignore[assignment]
         raw_msg = await self.adapter.post_message(self._id, postable)
-        result = self._create_sent_message(raw_msg.id, postable, raw_msg.thread_id)
+        result = self._create_sent_message(raw_msg.id, postable, raw_msg.thread_id, raw=raw_msg.raw)
 
         if self._message_history is not None:
             await self._message_history.append(self._id, _to_message(result))
@@ -1122,6 +1122,7 @@ class ThreadImpl:
         message_id: str,
         postable: AdapterPostableMessage,
         thread_id_override: str | None = None,
+        raw: Any = None,
     ) -> SentMessage:
         adapter = self.adapter
         thread_id = thread_id_override or self._id
@@ -1160,7 +1161,7 @@ class ThreadImpl:
             ),
             attachments=attachments,
             links=[],
-            raw=None,
+            raw=raw,
             _edit=_edit,
             _delete=_delete,
             _add_reaction=_add_reaction,

--- a/tests/test_slack_api.py
+++ b/tests/test_slack_api.py
@@ -237,6 +237,63 @@ class TestPostMessage:
         assert len(client.get_calls("chat_postMessage")) == chat_post_calls_before
 
     @pytest.mark.asyncio
+    async def test_file_only_post_surfaces_confirmed_upload_ids(self):
+        """File-only post exposes Slack-confirmed file IDs on ``RawMessage.raw``."""
+        adapter, client, _ = await _init_adapter()
+        client.set_response(
+            "files_upload_v2",
+            {"ok": True, "files": [{"files": [{"id": "F1"}, {"id": "F2"}]}]},
+        )
+
+        from chat_sdk.types import FileUpload, PostableMarkdown
+
+        msg = PostableMarkdown(
+            markdown="",
+            files=[FileUpload(data=b"hello", filename="test.txt")],
+        )
+        result = await adapter.post_message("slack:C123:1234567890.000000", msg)
+
+        assert isinstance(result.raw, dict)
+        assert result.raw["uploaded_file_ids"] == ["F1", "F2"]
+        # The original raw payload is preserved (augment, don't replace).
+        assert "files" in result.raw
+
+    @pytest.mark.asyncio
+    async def test_text_with_files_surfaces_confirmed_upload_ids(self):
+        """Text + files post augments the chat_postMessage raw with confirmed IDs."""
+        adapter, client, _ = await _init_adapter()
+        client.set_response("chat_postMessage", {"ok": True, "ts": "1234567890.222222"})
+        client.set_response(
+            "files_upload_v2",
+            {"ok": True, "files": [{"files": [{"id": "F9"}]}]},
+        )
+
+        from chat_sdk.types import FileUpload, PostableMarkdown
+
+        msg = PostableMarkdown(
+            markdown="here is the report",
+            files=[FileUpload(data=b"hello", filename="report.txt")],
+        )
+        result = await adapter.post_message("slack:C123:1234567890.000000", msg)
+
+        assert result.id == "1234567890.222222"
+        assert isinstance(result.raw, dict)
+        assert result.raw["uploaded_file_ids"] == ["F9"]
+        # The Slack chat_postMessage response is preserved alongside the IDs.
+        assert result.raw["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_text_only_post_does_not_add_uploaded_file_ids(self):
+        """Posts without files leave ``raw`` unaugmented (no ``uploaded_file_ids`` key)."""
+        adapter, client, _ = await _init_adapter()
+        client.set_response("chat_postMessage", {"ok": True, "ts": "1234567890.333333"})
+
+        result = await adapter.post_message("slack:C123:1234567890.000000", "plain text")
+
+        assert isinstance(result.raw, dict)
+        assert "uploaded_file_ids" not in result.raw
+
+    @pytest.mark.asyncio
     async def test_file_upload_uses_channel_kwarg_not_channel_id(self):
         """Regression: slack-sdk's files_upload_v2 takes ``channel=``, not ``channel_id=``.
 

--- a/tests/test_thread_faithful.py
+++ b/tests/test_thread_faithful.py
@@ -260,6 +260,29 @@ class TestPostWithDifferentMessageFormats:
         result = await thread.post("Hello")
         assert result.thread_id == "slack:C123:new-thread-id"
 
+    # it("should propagate adapter RawMessage.raw onto SentMessage.raw")
+    @pytest.mark.asyncio
+    async def test_should_propagate_adapter_raw_onto_sent_message(self):
+        """post() must carry the adapter's RawMessage.raw through to
+        SentMessage.raw so consumers can read platform confirmation data
+        (e.g. Slack's ``uploaded_file_ids``)."""
+        adapter = create_mock_adapter()
+        state = create_mock_state()
+
+        async def custom_post(thread_id: str, message: Any) -> RawMessage:
+            return RawMessage(
+                id="msg-3",
+                thread_id=thread_id,
+                raw={"ok": True, "uploaded_file_ids": ["F1", "F2"]},
+            )
+
+        adapter.post_message = custom_post  # type: ignore[assignment]
+        thread = _make_thread(adapter, state)
+        result = await thread.post(PostableMarkdown(markdown="report", files=[]))
+
+        assert isinstance(result.raw, dict)
+        assert result.raw["uploaded_file_ids"] == ["F1", "F2"]
+
 
 # ===========================================================================
 # Streaming


### PR DESCRIPTION
## Summary

**Point release 0.4.27.1** — Python-only patch on the 0.4.27 line. Does NOT include the 0.4.29 alpha sync work currently in flight on main. Branched off `v0.4.27` tag.

Unblocks chinchill-api consumer that needs to gate UX on actual Slack file-delivery confirmation, ahead of the 0.4.29 release.

## What's in 0.4.27.1

- **Slack `files_upload_v2` confirmation surfaced through `post()`** (backported from #117). `SlackAdapter._upload_files` already computed the list of Slack-confirmed file IDs but `post_message` discarded the return, and `ThreadImpl._create_sent_message` hardcoded `raw=None`. Now: `post_message` augments `RawMessage.raw` with `"uploaded_file_ids"` on every file-carrying return path; `_create_sent_message` accepts and propagates the adapter's `raw`. `None` = no upload; empty list = Slack confirmed zero. Augmentation is additive, not a replace.

- **Storage-bloat / PII fix** — `chat._MessageHistoryCache.append` now nulls `raw` before persisting (mirror of the existing null-out in `message_history.MessageHistoryCache.append`). Without this, the platform payload that the above fix populates on `SentMessage.raw` (Slack `team_id`/`user_id`, Discord `guildId`, etc.) would persist on every reply to Redis/Postgres-backed state. **Caught by post-merge code review of #117.**

## Why a point release vs waiting for 0.4.29

0.4.29 is still in mid-wave (alpha 1 just landed; chat/ai, Messenger, and other big pieces still in flight). chinchill-api can't wait. Branching off `v0.4.27` for a focused patch gets the fix to production immediately without coupling to 4.29's risk surface.

## Release mechanics

- **Base**: `v0.4.27` tag (`c43ea05`)
- **Branch**: `release/0.4.27.1`
- **PR target**: `main` (for visibility / CI / review). **Not intended for merge into main** — main is already on `0.4.29a1` and merging would conflict on version + CHANGELOG. After approval, tag `v0.4.27.1` from `release/0.4.27.1` directly; CHANGELOG entry will be forward-ported to main via a separate small PR.

## Validation

- `ruff check` + `ruff format --check`: clean
- `audit_test_quality.py`: 0 hard failures
- Full suite: **4040 passed, 3 skipped** on Python 3.12

## Upstream convergence

Filing the same fix upstream (vercel/chat#564) to restore parity in a future sync.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj)_