### PR TITLE
fix(slack): timing-safe socket-token comparison (port 9824d33 slice)

### DIFF
--- a/src/chat_sdk/adapters/slack/adapter.py
+++ b/src/chat_sdk/adapters/slack/adapter.py
@@ -1235,8 +1235,14 @@ class SlackAdapter:
         # success.
         socket_token = headers.get("x-slack-socket-token") or headers.get("X-Slack-Socket-Token")
         if socket_token:
+            # Constant-time bearer comparison (upstream timingSafeStringEqual,
+            # 9824d33 / PR #441). Encode both operands to UTF-8 bytes so
+            # ``compare_digest`` mirrors upstream's ``Buffer.from(x, "utf8")``
+            # comparison: it returns False on length mismatch (the secret's
+            # length is fixed at config time, so that is not a leak) and never
+            # raises on non-ASCII tokens the way str comparison would.
             if not self._socket_forwarding_secret or not hmac.compare_digest(
-                socket_token, self._socket_forwarding_secret
+                socket_token.encode(), self._socket_forwarding_secret.encode()
             ):
                 self._logger.warn("Invalid socket forwarding token")
                 return {"body": "Invalid socket token", "status": 401}

--- a/tests/test_slack_socket_mode.py
+++ b/tests/test_slack_socket_mode.py
@@ -343,6 +343,85 @@ class TestForwardedSocketEvents:
         result = await adapter.handle_webhook(request)
         assert result["status"] == 401
 
+    async def test_webhook_socket_token_uses_timing_safe_compare(self, monkeypatch):
+        """The socket-token check MUST route through ``hmac.compare_digest``.
+
+        Upstream switched this comparison to a constant-time check
+        (timingSafeStringEqual, 9824d33 / PR #441). This is the load-bearing
+        guard against a regression to a plain ``==`` / ``!=`` comparison:
+        we spy on ``hmac.compare_digest`` as referenced by the adapter module
+        and assert it is invoked for the socket token, with both operands
+        encoded to bytes (mirroring upstream's ``Buffer.from(x, "utf8")``).
+        """
+        import time as _time
+
+        from chat_sdk.adapters.slack import adapter as adapter_mod
+
+        calls: list[tuple[Any, Any]] = []
+        real_compare = adapter_mod.hmac.compare_digest
+
+        def _spy_compare(a, b):
+            calls.append((a, b))
+            return real_compare(a, b)
+
+        monkeypatch.setattr(adapter_mod.hmac, "compare_digest", _spy_compare)
+
+        adapter = _make_socket_adapter(socket_forwarding_secret="fwd-secret")
+        chat = _make_mock_chat()
+        adapter._chat = chat
+        forwarded = {
+            "type": "socket_event",
+            "eventType": "events_api",
+            "body": {
+                "type": "event_callback",
+                "event": {
+                    "type": "message",
+                    "channel": "C123",
+                    "ts": "1.0",
+                    "user": "U1",
+                    "text": "hi",
+                    "team": "T1",
+                },
+                "team_id": "T1",
+            },
+            "timestamp": int(_time.time()),
+        }
+        request = _FakeRequest(
+            json.dumps(forwarded),
+            headers={
+                "content-type": "application/json",
+                "x-slack-socket-token": "fwd-secret",
+            },
+        )
+        result = await adapter.handle_webhook(request)
+
+        # Valid token => accepted, AND the timing-safe path was exercised
+        # with byte-encoded operands.
+        assert result["status"] == 200
+        assert (b"fwd-secret", b"fwd-secret") in calls, (
+            f"socket token must be compared via hmac.compare_digest on bytes, not == ; recorded calls: {calls!r}"
+        )
+
+    async def test_webhook_socket_token_non_ascii_rejected_not_crash(self):
+        """A non-ASCII socket token must be rejected (401), never crash.
+
+        ``hmac.compare_digest`` raises ``TypeError`` on non-ASCII ``str``
+        operands; encoding to bytes (the upstream behavior) avoids that. This
+        pins the ``.encode()`` so a regression to str comparison surfaces as a
+        crash here rather than silently in production.
+        """
+        adapter = _make_socket_adapter(socket_forwarding_secret="fwd-secret")
+        adapter._chat = _make_mock_chat()
+        request = _FakeRequest(
+            json.dumps({"type": "socket_event", "eventType": "events_api", "body": {}}),
+            headers={
+                "content-type": "application/json",
+                "x-slack-socket-token": "café-not-the-secret",
+            },
+        )
+        result = await adapter.handle_webhook(request)
+        assert result["status"] == 401
+
 
 # ---------------------------------------------------------------------------
 # _route_socket_event dispatch


### PR DESCRIPTION
## What's ported

Slack slice of upstream `9824d33` (PR #441 adapter-hardening pass). Refs #98 (worklist item P1-4).

Upstream switched the `x-slack-socket-token` bearer check (the token authenticating forwarded Socket Mode events POSTed back to the webhook endpoint) from a plain string compare to a constant-time `timingSafeStringEqual`. This ports that to the Python adapter.

### Change
`src/chat_sdk/adapters/slack/adapter.py` — in the forwarded-socket branch of `handle_webhook`, the bearer comparison now encodes both operands to UTF-8 bytes before `hmac.compare_digest`:

```python
if not self._socket_forwarding_secret or not hmac.compare_digest(
    socket_token.encode(), self._socket_forwarding_secret.encode()
):
```

This mirrors upstream `timingSafeStringEqual`'s `Buffer.from(x, "utf8")` byte comparison:
- Keeps the constant-time guarantee (per CLAUDE.md Port Rule: `==` for signatures → `hmac.compare_digest`).
- Returns `False` on length mismatch (the secret length is fixed at config time, so that is not a leaking signal — matching upstream's comment).
- Rejects (401), rather than crashing, on a non-ASCII token: `str` `compare_digest` raises `TypeError` on non-ASCII; encoding to bytes avoids that.
- Still refuses when no secret is configured (Hazard #12: no empty-header match as success).

Behavior otherwise unchanged: missing secret → 401, mismatch → 401, valid → continues to the freshness check then routes the event.

The change is localized to the socket-token validation block and does not touch the `web_client` / client-exposure code (a separate in-flight PR `claude/port-slack-web-client` edits a different method in this file).

### Tests
`tests/test_slack_socket_mode.py` (`TestForwardedSocketEvents`):
- `test_webhook_socket_token_uses_timing_safe_compare` — `monkeypatch` spies on `hmac.compare_digest` and asserts it is invoked with the byte-encoded operands `(b"fwd-secret", b"fwd-secret")`. **Load-bearing**: verified to fail if the source regresses to `==`.
- `test_webhook_socket_token_non_ascii_rejected_not_crash` — a non-ASCII token returns 401 instead of raising (pins the `.encode()`).
- Existing valid-accepted / invalid-rejected / missing-secret-rejected cases retained.

## Scope note

This is **1 of 4 slices** of the `9824d33` security pass. The gchat / github / linear slices ship as separate PRs.

**Does not** edit CHANGELOG or bump `pyproject.toml` — the cut PR handles versioning.

## Validation

```
uv run ruff check src/ tests/                  # All checks passed!
uv run ruff format --check src/ tests/         # 195 files already formatted
uv run python scripts/audit_test_quality.py    # Hard failures: 0
uv run pytest tests/ -k slack -q               # 623 passed, 3429 deselected
uv run pytest tests/ -q                        # 4049 passed, 3 skipped (no regressions)
```

https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj)_