### PR TITLE
feat(linear): encrypt OAuth tokens at rest (AES-256-GCM)

### DIFF
--- a/src/chat_sdk/adapters/linear/__init__.py
+++ b/src/chat_sdk/adapters/linear/__init__.py
@@ -1,5 +1,6 @@
 """Linear adapter for chat-sdk."""
 
 from chat_sdk.adapters.linear.adapter import LinearAdapter, create_linear_adapter
+from chat_sdk.adapters.linear.types import LinearInstallation
 
-__all__ = ["LinearAdapter", "create_linear_adapter"]
+__all__ = ["LinearAdapter", "LinearInstallation", "create_linear_adapter"]

--- a/src/chat_sdk/adapters/linear/adapter.py
+++ b/src/chat_sdk/adapters/linear/adapter.py
@@ -26,10 +26,24 @@ from chat_sdk.adapters.linear.types import (
     LinearAdapterBaseConfig,
     LinearAdapterConfig,
     LinearCommentData,
+    LinearInstallation,
     LinearRawMessage,
     LinearThreadId,
     LinearWebhookActor,
     ReactionWebhookPayload,
+)
+
+# AES-256-GCM token-at-rest encryption helpers. These live under the Slack
+# adapter package but are platform-agnostic (a faithful port of upstream's
+# shared ``adapter-shared/crypto.ts``); reuse them rather than duplicating the
+# crypto primitives. ``cryptography`` is imported lazily inside encrypt/decrypt
+# so adapters that don't configure a key don't require the dependency.
+from chat_sdk.adapters.slack.crypto import (
+    EncryptedTokenData,
+    decode_key,
+    decrypt_token,
+    encrypt_token,
+    is_encrypted_token_data,
 )
 from chat_sdk.emoji import convert_emoji_placeholders
 from chat_sdk.logger import ConsoleLogger, Logger
@@ -160,6 +174,25 @@ class LinearAdapter:
                             "or LINEAR_CLIENT_ID/LINEAR_CLIENT_SECRET, or provide auth in config.",
                         )
 
+        # State-key prefix for per-organization installations.
+        self._installation_key_prefix = getattr(config, "installation_key_prefix", None) or "linear:installation"
+
+        # Optional AES-256-GCM key for encrypting OAuth tokens at rest. Use
+        # ``is not None`` (not truthiness) so an explicit ``encryption_key=""``
+        # is treated as "user explicitly opted out" and is NOT silently
+        # shadowed by ``LINEAR_ENCRYPTION_KEY`` from the env (CLAUDE.md
+        # truthiness-trap hazard). An empty user value still short-circuits
+        # ``decode_key`` via the ``if encryption_key_raw`` guard, so no broken
+        # key is ever built.
+        config_encryption_key = getattr(config, "encryption_key", None)
+        if config_encryption_key is not None:
+            encryption_key_raw: str | None = config_encryption_key
+        else:
+            encryption_key_raw = os.environ.get("LINEAR_ENCRYPTION_KEY")
+        self._encryption_key: bytes | None = None
+        if encryption_key_raw:
+            self._encryption_key = decode_key(encryption_key_raw)
+
     @property
     def name(self) -> str:
         return self._name
@@ -258,6 +291,137 @@ class LinearAdapter:
             if self._access_token_expiry and time.time() > self._access_token_expiry:
                 self._logger.info("Linear access token expired, refreshing...")
                 await self._refresh_client_credentials_token()
+
+    # ------------------------------------------------------------------
+    # Multi-tenant installation persistence (with optional encryption)
+    # ------------------------------------------------------------------
+
+    def _installation_key(self, organization_id: str) -> str:
+        return f"{self._installation_key_prefix}:{organization_id}"
+
+    async def set_installation(self, organization_id: str, installation: LinearInstallation) -> None:
+        """Persist a Linear installation for an organization.
+
+        Used in multi-tenant mode after a successful OAuth exchange. When an
+        ``encryption_key`` is configured, ``access_token`` / ``refresh_token``
+        are AES-256-GCM-encrypted before being written to the state store.
+        """
+        if not self._chat:
+            raise ValidationError(
+                "linear",
+                "Adapter not initialized. Ensure chat.initialize() has been called first.",
+            )
+
+        state = self._chat.get_state()
+        key = self._installation_key(organization_id)
+        await state.set(key, self._encrypt_installation(installation))
+        self._logger.info("Linear installation saved", {"organizationId": organization_id})
+
+    async def get_installation(self, organization_id: str) -> LinearInstallation | None:
+        """Retrieve a Linear installation for an organization.
+
+        Decrypts ``access_token`` / ``refresh_token`` when they were stored as
+        encrypted envelopes. Tolerates plaintext records written before
+        encryption was enabled, so a key can be rotated in with zero downtime.
+        """
+        if not self._chat:
+            raise ValidationError(
+                "linear",
+                "Adapter not initialized. Ensure chat.initialize() has been called first.",
+            )
+
+        state = self._chat.get_state()
+        stored = await state.get(self._installation_key(organization_id))
+        if not stored or not isinstance(stored, dict):
+            return None
+
+        return self._decrypt_installation(stored)
+
+    async def delete_installation(self, organization_id: str) -> None:
+        """Remove a Linear installation. Used for uninstall handling."""
+        if not self._chat:
+            raise ValidationError(
+                "linear",
+                "Adapter not initialized. Ensure chat.initialize() has been called first.",
+            )
+
+        state = self._chat.get_state()
+        await state.delete(self._installation_key(organization_id))
+        self._logger.info("Linear installation deleted", {"organizationId": organization_id})
+
+    def _encrypt_installation(self, installation: LinearInstallation) -> dict[str, Any]:
+        """Serialize an installation for storage, encrypting tokens if a key is set.
+
+        Without a key, tokens are stored as plaintext (legacy behavior).
+        Field names use camelCase to match the persisted-JSON boundary
+        convention (CLAUDE.md) and upstream's ``StoredLinearInstallation``.
+        """
+        data: dict[str, Any] = {
+            "botUserId": installation.bot_user_id,
+            "expiresAt": installation.expires_at,
+            "organizationId": installation.organization_id,
+        }
+
+        if self._encryption_key:
+            access = encrypt_token(installation.access_token, self._encryption_key)
+            data["accessToken"] = {"iv": access.iv, "data": access.data, "tag": access.tag}
+            if installation.refresh_token is not None:
+                refresh = encrypt_token(installation.refresh_token, self._encryption_key)
+                data["refreshToken"] = {"iv": refresh.iv, "data": refresh.data, "tag": refresh.tag}
+        else:
+            data["accessToken"] = installation.access_token
+            if installation.refresh_token is not None:
+                data["refreshToken"] = installation.refresh_token
+
+        return data
+
+    def _decrypt_installation(self, stored: dict[str, Any]) -> LinearInstallation:
+        """Reconstruct an installation from storage, decrypting tokens as needed."""
+        # Tolerate both camelCase (this port / upstream) and snake_case keys.
+        raw_access = stored.get("accessToken")
+        if raw_access is None:
+            raw_access = stored.get("access_token")
+        raw_refresh = stored.get("refreshToken")
+        if raw_refresh is None:
+            raw_refresh = stored.get("refresh_token")
+
+        access_token = self._maybe_decrypt(raw_access)
+        refresh_token = None if raw_refresh is None else self._maybe_decrypt(raw_refresh)
+
+        return LinearInstallation(
+            access_token=access_token if access_token is not None else "",
+            organization_id=stored.get("organizationId") or stored.get("organization_id") or "",
+            bot_user_id=stored.get("botUserId") or stored.get("bot_user_id"),
+            expires_at=stored.get("expiresAt") if stored.get("expiresAt") is not None else stored.get("expires_at"),
+            refresh_token=refresh_token,
+        )
+
+    def _maybe_decrypt(self, value: Any) -> str | None:
+        """Decrypt an encrypted-token envelope, or pass through a plaintext value.
+
+        Plaintext tolerance: a value that is not an encrypted envelope (e.g. a
+        record written before encryption was enabled) is returned unchanged.
+
+        Raises:
+            ValidationError: if an encrypted envelope is read but no key is
+                configured -- a clear error instead of returning ciphertext.
+        """
+        if value is None:
+            return None
+        if is_encrypted_token_data(value):
+            if not self._encryption_key:
+                raise ValidationError(
+                    "linear",
+                    "Stored Linear installation token is encrypted but no encryption_key is "
+                    "configured. Set LINEAR_ENCRYPTION_KEY (or config.encryption_key) to the key "
+                    "used when the installation was saved.",
+                )
+            return decrypt_token(
+                EncryptedTokenData(iv=value["iv"], data=value["data"], tag=value["tag"]),
+                self._encryption_key,
+            )
+        # Plaintext value (legacy / no encryption configured at write time).
+        return value if isinstance(value, str) else str(value)
 
     async def get_user(self, user_id: str) -> UserInfo | None:
         """Look up a Linear user by UUID via the GraphQL ``user`` query.

--- a/src/chat_sdk/adapters/linear/adapter.py
+++ b/src/chat_sdk/adapters/linear/adapter.py
@@ -174,8 +174,12 @@ class LinearAdapter:
                             "or LINEAR_CLIENT_ID/LINEAR_CLIENT_SECRET, or provide auth in config.",
                         )
 
-        # State-key prefix for per-organization installations.
-        self._installation_key_prefix = getattr(config, "installation_key_prefix", None) or "linear:installation"
+        # State-key prefix for per-organization installations. Use ``is not
+        # None`` (not truthiness) so an explicit ``installation_key_prefix=""``
+        # is honored verbatim and NOT silently overridden by the default
+        # (CLAUDE.md truthiness-trap hazard).
+        prefix = getattr(config, "installation_key_prefix", None)
+        self._installation_key_prefix = prefix if prefix is not None else "linear:installation"
 
         # Optional AES-256-GCM key for encrypting OAuth tokens at rest. Use
         # ``is not None`` (not truthiness) so an explicit ``encryption_key=""``

--- a/src/chat_sdk/adapters/linear/types.py
+++ b/src/chat_sdk/adapters/linear/types.py
@@ -28,6 +28,17 @@ class LinearAdapterBaseConfig:
     # Webhook signing secret for HMAC-SHA256 verification.
     # Defaults to LINEAR_WEBHOOK_SECRET env var.
     webhook_secret: str | None = None
+    # Optional 32-byte AES-256-GCM key used to encrypt OAuth ``access_token``
+    # and ``refresh_token`` values at rest in the state store. Accepts either a
+    # 64-char hex string or a 44-char base64 string. Defaults to the
+    # ``LINEAR_ENCRYPTION_KEY`` env var. Strongly recommended for multi-tenant
+    # deployments -- without it, a state-store compromise yields plaintext
+    # per-tenant Linear API tokens. When unset, installations are stored as
+    # plaintext (legacy behavior).
+    encryption_key: str | None = None
+    # Prefix for the state key used to store per-organization installations.
+    # Defaults to ``linear:installation``. The full key is ``{prefix}:{org_id}``.
+    installation_key_prefix: str = "linear:installation"
 
 
 @dataclass
@@ -69,6 +80,28 @@ class LinearAdapterAppConfig(LinearAdapterBaseConfig):
 LinearAdapterConfig = (
     LinearAdapterBaseConfig | LinearAdapterAPIKeyConfig | LinearAdapterOAuthConfig | LinearAdapterAppConfig
 )
+
+
+# =============================================================================
+# Installation
+# =============================================================================
+
+
+@dataclass
+class LinearInstallation:
+    """Per-organization OAuth installation persisted to the state store.
+
+    Used in multi-tenant mode after a successful OAuth exchange. When an
+    ``encryption_key`` is configured on the adapter, ``access_token`` and
+    ``refresh_token`` are AES-256-GCM-encrypted at rest; the in-memory form
+    always holds plaintext.
+    """
+
+    access_token: str
+    organization_id: str
+    bot_user_id: str | None = None
+    expires_at: int | None = None
+    refresh_token: str | None = None
 
 
 # =============================================================================

--- a/tests/test_linear_encryption.py
+++ b/tests/test_linear_encryption.py
@@ -1,0 +1,244 @@
+"""Tests for at-rest AES-256-GCM encryption of Linear OAuth tokens.
+
+Port of the Linear slice of upstream ``9824d33`` (PR #441 adapter-hardening):
+``encryptInstallation`` / ``decryptInstallation`` / ``maybeDecrypt`` in
+packages/adapter-linear/src/index.ts, with plaintext-tolerance for a
+zero-downtime rollout.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from chat_sdk.adapters.linear.adapter import LinearAdapter
+from chat_sdk.adapters.linear.types import (
+    LinearAdapterAppConfig,
+    LinearInstallation,
+)
+from chat_sdk.shared.errors import ValidationError
+from chat_sdk.state.memory import MemoryStateAdapter
+
+WEBHOOK_SECRET = "test-webhook-secret"
+KEY_BYTES = os.urandom(32)
+KEY_B64 = base64.b64encode(KEY_BYTES).decode("ascii")
+KEY_HEX = KEY_BYTES.hex()
+
+
+async def _make_adapter(encryption_key: str | None = None) -> LinearAdapter:
+    """Create an initialized multi-tenant adapter wired to a MemoryState."""
+    adapter = LinearAdapter(
+        LinearAdapterAppConfig(
+            client_id="cid",
+            client_secret="csecret",
+            webhook_secret=WEBHOOK_SECRET,
+            encryption_key=encryption_key,
+        )
+    )
+    state = MemoryStateAdapter()
+    await state.connect()
+
+    class _Chat:
+        def get_state(self):
+            return state
+
+    adapter._chat = _Chat()  # type: ignore[assignment]
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptionKeyResolution:
+    def test_no_key_leaves_encryption_disabled(self):
+        adapter = LinearAdapter(LinearAdapterAppConfig(client_id="c", client_secret="s", webhook_secret=WEBHOOK_SECRET))
+        assert adapter._encryption_key is None
+
+    def test_base64_key_decoded(self):
+        adapter = LinearAdapter(
+            LinearAdapterAppConfig(
+                client_id="c", client_secret="s", webhook_secret=WEBHOOK_SECRET, encryption_key=KEY_B64
+            )
+        )
+        assert adapter._encryption_key == KEY_BYTES
+
+    def test_hex_key_decoded(self):
+        adapter = LinearAdapter(
+            LinearAdapterAppConfig(
+                client_id="c", client_secret="s", webhook_secret=WEBHOOK_SECRET, encryption_key=KEY_HEX
+            )
+        )
+        assert adapter._encryption_key == KEY_BYTES
+
+    def test_env_fallback_used_when_config_unset(self, monkeypatch):
+        monkeypatch.setenv("LINEAR_ENCRYPTION_KEY", KEY_B64)
+        adapter = LinearAdapter(LinearAdapterAppConfig(client_id="c", client_secret="s", webhook_secret=WEBHOOK_SECRET))
+        assert adapter._encryption_key == KEY_BYTES
+
+    def test_explicit_empty_string_opts_out_of_env(self, monkeypatch):
+        # An explicit empty key means "opted out"; the env var must NOT shadow
+        # it (distinguish unset from empty -- truthiness-trap hazard).
+        monkeypatch.setenv("LINEAR_ENCRYPTION_KEY", KEY_B64)
+        adapter = LinearAdapter(
+            LinearAdapterAppConfig(client_id="c", client_secret="s", webhook_secret=WEBHOOK_SECRET, encryption_key="")
+        )
+        assert adapter._encryption_key is None
+
+
+# ---------------------------------------------------------------------------
+# Round-trip and storage shape
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptRoundTrip:
+    @pytest.mark.asyncio
+    async def test_round_trip_yields_original_tokens(self):
+        adapter = await _make_adapter(encryption_key=KEY_B64)
+        await adapter.set_installation(
+            "org-1",
+            LinearInstallation(
+                access_token="lin_oauth_access_abc",
+                organization_id="org-1",
+                bot_user_id="bot-1",
+                expires_at=1234,
+                refresh_token="lin_oauth_refresh_xyz",
+            ),
+        )
+
+        loaded = await adapter.get_installation("org-1")
+        assert loaded is not None
+        assert loaded.access_token == "lin_oauth_access_abc"
+        assert loaded.refresh_token == "lin_oauth_refresh_xyz"
+        assert loaded.organization_id == "org-1"
+        assert loaded.bot_user_id == "bot-1"
+        assert loaded.expires_at == 1234
+
+    @pytest.mark.asyncio
+    async def test_tokens_are_encrypted_in_state(self):
+        adapter = await _make_adapter(encryption_key=KEY_B64)
+        await adapter.set_installation(
+            "org-2",
+            LinearInstallation(access_token="secret-access", organization_id="org-2"),
+        )
+
+        raw = await adapter._chat.get_state().get("linear:installation:org-2")
+        # Stored as an encrypted envelope, not the plaintext token.
+        assert isinstance(raw["accessToken"], dict)
+        assert set(raw["accessToken"]) == {"iv", "data", "tag"}
+        assert "secret-access" not in str(raw["accessToken"])
+        # No refresh token supplied -> field omitted.
+        assert "refreshToken" not in raw
+
+    @pytest.mark.asyncio
+    async def test_no_key_stores_plaintext(self):
+        adapter = await _make_adapter(encryption_key=None)
+        await adapter.set_installation(
+            "org-3",
+            LinearInstallation(access_token="plain-access", organization_id="org-3"),
+        )
+        raw = await adapter._chat.get_state().get("linear:installation:org-3")
+        assert raw["accessToken"] == "plain-access"
+
+        loaded = await adapter.get_installation("org-3")
+        assert loaded is not None
+        assert loaded.access_token == "plain-access"
+
+    @pytest.mark.asyncio
+    async def test_nonce_uniqueness_across_encryptions(self):
+        adapter = await _make_adapter(encryption_key=KEY_B64)
+        await adapter.set_installation("org-a", LinearInstallation(access_token="same-token", organization_id="org-a"))
+        await adapter.set_installation("org-b", LinearInstallation(access_token="same-token", organization_id="org-b"))
+        raw_a = await adapter._chat.get_state().get("linear:installation:org-a")
+        raw_b = await adapter._chat.get_state().get("linear:installation:org-b")
+        # Same plaintext, fresh random nonce each time -> distinct iv + ciphertext.
+        assert raw_a["accessToken"]["iv"] != raw_b["accessToken"]["iv"]
+        assert raw_a["accessToken"]["data"] != raw_b["accessToken"]["data"]
+
+
+# ---------------------------------------------------------------------------
+# Plaintext tolerance (zero-downtime rollout)
+# ---------------------------------------------------------------------------
+
+
+class TestPlaintextTolerance:
+    @pytest.mark.asyncio
+    async def test_plaintext_record_read_with_key_configured(self):
+        # Simulate a record written BEFORE encryption was enabled, then read
+        # back after a key was rotated in. It must decrypt-read as-is.
+        adapter = await _make_adapter(encryption_key=KEY_B64)
+        await adapter._chat.get_state().set(
+            "linear:installation:legacy",
+            {
+                "accessToken": "legacy-plaintext-access",
+                "refreshToken": "legacy-plaintext-refresh",
+                "organizationId": "legacy",
+                "botUserId": "bot-legacy",
+                "expiresAt": 999,
+            },
+        )
+        loaded = await adapter.get_installation("legacy")
+        assert loaded is not None
+        assert loaded.access_token == "legacy-plaintext-access"
+        assert loaded.refresh_token == "legacy-plaintext-refresh"
+        assert loaded.bot_user_id == "bot-legacy"
+        assert loaded.expires_at == 999
+
+    @pytest.mark.asyncio
+    async def test_missing_installation_returns_none(self):
+        adapter = await _make_adapter(encryption_key=KEY_B64)
+        assert await adapter.get_installation("does-not-exist") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_installation(self):
+        adapter = await _make_adapter(encryption_key=KEY_B64)
+        await adapter.set_installation("org-del", LinearInstallation(access_token="tok", organization_id="org-del"))
+        assert await adapter.get_installation("org-del") is not None
+        await adapter.delete_installation("org-del")
+        assert await adapter.get_installation("org-del") is None
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptionErrors:
+    @pytest.mark.asyncio
+    async def test_encrypted_record_without_key_raises_clear_error(self):
+        # Write encrypted, then read with a fresh adapter that has NO key.
+        writer = await _make_adapter(encryption_key=KEY_B64)
+        await writer.set_installation(
+            "org-enc", LinearInstallation(access_token="enc-token", organization_id="org-enc")
+        )
+        stored = await writer._chat.get_state().get("linear:installation:org-enc")
+
+        reader = await _make_adapter(encryption_key=None)
+        await reader._chat.get_state().set("linear:installation:org-enc", stored)
+        with pytest.raises(ValidationError, match="encrypted but no encryption_key"):
+            await reader.get_installation("org-enc")
+
+    @pytest.mark.asyncio
+    async def test_wrong_key_fails_loudly(self):
+        writer = await _make_adapter(encryption_key=KEY_B64)
+        await writer.set_installation(
+            "org-wrong", LinearInstallation(access_token="enc-token", organization_id="org-wrong")
+        )
+        stored = await writer._chat.get_state().get("linear:installation:org-wrong")
+
+        wrong_key = base64.b64encode(os.urandom(32)).decode("ascii")
+        reader = await _make_adapter(encryption_key=wrong_key)
+        await reader._chat.get_state().set("linear:installation:org-wrong", stored)
+        # GCM auth-tag verification fails loudly -- never returns silent garbage.
+        with pytest.raises(InvalidTag):
+            await reader.get_installation("org-wrong")
+
+    @pytest.mark.asyncio
+    async def test_set_installation_before_initialize_raises(self):
+        adapter = LinearAdapter(LinearAdapterAppConfig(client_id="c", client_secret="s", webhook_secret=WEBHOOK_SECRET))
+        with pytest.raises(ValidationError, match="not initialized"):
+            await adapter.set_installation("o", LinearInstallation(access_token="t", organization_id="o"))

--- a/tests/test_linear_encryption.py
+++ b/tests/test_linear_encryption.py
@@ -89,6 +89,21 @@ class TestEncryptionKeyResolution:
         )
         assert adapter._encryption_key is None
 
+    def test_explicit_empty_installation_key_prefix_is_honored(self):
+        # An explicit empty prefix ("") is a valid caller choice and must NOT
+        # be silently overridden by the default. A truthiness fallback
+        # (``... or "linear:installation"``) would discard "" and yield the
+        # default; an explicit ``is not None`` check preserves it.
+        adapter = LinearAdapter(
+            LinearAdapterAppConfig(
+                client_id="c",
+                client_secret="s",
+                webhook_secret=WEBHOOK_SECRET,
+                installation_key_prefix="",
+            )
+        )
+        assert adapter._installation_key_prefix == ""
+
 
 # ---------------------------------------------------------------------------
 # Round-trip and storage shape


### PR DESCRIPTION
## What's ported

The **Linear slice** of upstream [`9824d33`](https://github.com/vercel/chat/commit/9824d33) (PR #441 adapter-hardening, a 4-part security pass). This adds optional **AES-256-GCM encryption of OAuth tokens at rest** to the Linear adapter, mirroring `encryptInstallation` / `decryptInstallation` / `maybeDecrypt` and the `isEncryptedTokenData` discriminator in `packages/adapter-linear/src/index.ts`.

Worklist item **P1-7**. Tracking: #98.

> Note: this is one of the four adapters touched by `9824d33`. The Slack slice already landed earlier in the port (the shared crypto helpers live in `chat_sdk.adapters.slack.crypto`); this PR is the Linear slice. The remaining slices are tracked separately.

## Changes

- `LinearAdapterBaseConfig`: new optional `encryption_key: str | None` (+ `installation_key_prefix`). Resolved via the `x if x is not None else default` pattern with a `LINEAR_ENCRYPTION_KEY` env fallback. An explicit `encryption_key=""` means "opted out" and is **not** silently shadowed by the env var (distinguishes unset from empty — truthiness-trap hazard).
- New `LinearInstallation` dataclass + `set_installation` / `get_installation` / `delete_installation` for multi-tenant install persistence.
- When a key is configured, `access_token` / `refresh_token` are stored as an `EncryptedTokenData` envelope (`{iv, data, tag}`, all base64) and decrypted on read. When unset, behavior is unchanged (plaintext, as today).

## Crypto design

- **Reuse, no duplication:** the AES-256-GCM primitives in `chat_sdk.adapters.slack.crypto` are platform-agnostic (a faithful port of upstream's shared `adapter-shared/crypto.ts`); this PR imports them rather than copying crypto code.
- **Key derivation:** matches upstream `decodeKey` — a 64-char hex string or 44-char base64 string decoded to exactly **32 raw key bytes** (no hashing/KDF; the raw bytes are the AES-256 key). Wrong length raises `ValueError`.
- **Nonce handling:** a **fresh random 12-byte nonce per encryption** (via the `cryptography` lib's CSPRNG-backed `os.urandom`), stored as the `iv` field alongside the ciphertext. **Never reused.** 16-byte GCM auth tag stored as `tag`. Verified by a test asserting two encryptions of the same token yield distinct `iv` + ciphertext.

## Plaintext-tolerance rollout story

Zero-downtime: a deployer can turn encryption on without a migration.
- Records written **before** a key was configured have no `{iv, data, tag}` discriminator → `maybe_decrypt` returns them as-is.
- New writes (with a key) are encrypted.
- Reading an **encrypted** record with **no key configured** raises a clear `ValidationError` (not silent ciphertext).
- A **wrong key** fails loudly via GCM auth-tag verification (`InvalidTag`) — never silent garbage.

## `cryptography` dependency status

Already a project dependency — no new runtime dependency added. `cryptography>=42.0` is declared in both the `crypto` optional extra and the `dev` dependency group, and `AESGCM` imports cleanly. (For completeness, the `linear` extra itself currently lists only `aiohttp`; the crypto import is lazy, so adapters that don't configure a key never need it. Whether to add `cryptography` to the `linear` extra is left to the maintainer / cut PR.)

## Validation

- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean
- `uv run python scripts/audit_test_quality.py` — 0 hard failures
- `uv run pyrefly check` — 0 errors
- `uv run pytest tests/ -k linear -q` — 164 passed
- `uv run pytest tests/ -q` — **4062 passed, 3 skipped** (no regressions)

New tests (`tests/test_linear_encryption.py`, 15 tests): encrypt→decrypt round-trip, plaintext-record tolerance, missing-key-on-encrypted-record error, wrong-key loud failure, nonce uniqueness, plus config-resolution (hex/base64/env-fallback/empty-opt-out) and delete.

Refs #98

https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMxQn2BEAzmwKS1GZczKj)_