### PR TITLE
fix(gchat): clear cardsV2 on edit-to-text + Select/RadioSelect selectionInput parity

### DIFF
--- a/src/chat_sdk/adapters/google_chat/adapter.py
+++ b/src/chat_sdk/adapters/google_chat/adapter.py
@@ -1290,8 +1290,11 @@ class GoogleChatAdapter:
             )
             return
 
-        # Get value from parameters
+        # Buttons send value via parameters, while selection inputs return the
+        # chosen option through formInputs under the action ID.
         value = (common_event.get("parameters") or {}).get("value")
+        if value is None:
+            value = self._get_form_input_value(common_event.get("formInputs"), action_id)
 
         # Get space and message info
         space = (button_payload or {}).get("space")
@@ -1338,6 +1341,20 @@ class GoogleChatAdapter:
         )
 
         self._chat.process_action(action_event, options)
+
+    def _get_form_input_value(
+        self,
+        form_inputs: dict[str, Any] | None,
+        action_id: str,
+    ) -> str | None:
+        """Resolve a selection-input value from a card-click ``formInputs`` map.
+
+        Mirrors upstream ``getFormInputValue``: returns
+        ``formInputs[actionId].stringInputs.value[0]`` if present, else ``None``.
+        """
+        entry = (form_inputs or {}).get(action_id) or {}
+        values = (entry.get("stringInputs") or {}).get("value") or []
+        return values[0] if values else None
 
     def _handle_message_event(
         self,
@@ -1678,8 +1695,11 @@ class GoogleChatAdapter:
             response = await self._gchat_api_request(
                 "PATCH",
                 message_id,
-                body={"text": text},
-                params={"updateMask": "text"},
+                # Clear any stranded card when editing a card message down to
+                # plain text. GChat renders both text and cardsV2 if cardsV2 is
+                # left untouched, so send an empty list under the update mask.
+                body={"text": text, "cardsV2": []},
+                params={"updateMask": "text,cardsV2"},
             )
 
             self._logger.debug(

--- a/src/chat_sdk/adapters/google_chat/cards.py
+++ b/src/chat_sdk/adapters/google_chat/cards.py
@@ -133,7 +133,7 @@ def _convert_child_to_widgets(
     elif child_type == "divider":
         return [_convert_divider_to_widget()]
     elif child_type == "actions":
-        return [_convert_actions_to_widget(cast("dict[str, Any]", child), endpoint_url)]
+        return _convert_actions_to_widgets(cast("dict[str, Any]", child), endpoint_url)
     elif child_type == "section":
         return _convert_section_to_widgets(cast("dict[str, Any]", child), endpoint_url)
     elif child_type == "fields":
@@ -184,20 +184,71 @@ def _convert_divider_to_widget() -> dict[str, Any]:
     return {"divider": {}}
 
 
-def _convert_actions_to_widget(
+def _convert_actions_to_widgets(
+    element: dict[str, Any],
+    endpoint_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Convert an actions element to widgets.
+
+    Buttons accumulate into a single ``buttonList`` widget; ``select`` and
+    ``radio_select`` children become standalone ``selectionInput`` widgets,
+    interleaved in source order (any pending buttons are flushed first).
+    """
+    widgets: list[dict[str, Any]] = []
+    buttons: list[dict[str, Any]] = []
+
+    def flush_buttons() -> None:
+        if not buttons:
+            return
+        widgets.append({"buttonList": {"buttons": list(buttons)}})
+        buttons.clear()
+
+    for child in element.get("children", []):
+        child_type = child.get("type")
+        if child_type == "button":
+            buttons.append(_convert_button_to_google_button(child, endpoint_url))
+            continue
+        if child_type == "link-button":
+            buttons.append(_convert_link_button_to_google_button(child))
+            continue
+        if child_type in ("select", "radio_select"):
+            flush_buttons()
+            widgets.append(_convert_selection_input_to_widget(child, endpoint_url))
+
+    flush_buttons()
+
+    return widgets
+
+
+def _convert_selection_input_to_widget(
     element: dict[str, Any],
     endpoint_url: str | None = None,
 ) -> dict[str, Any]:
-    """Convert an actions element to a widget."""
-    buttons: list[dict[str, Any]] = []
-    for child in element.get("children", []):
-        child_type = child.get("type")
-        if child_type == "link-button":
-            buttons.append(_convert_link_button_to_google_button(child))
-        elif child_type == "button":
-            buttons.append(_convert_button_to_google_button(child, endpoint_url))
+    """Convert a select/radio_select element to a ``selectionInput`` widget."""
+    initial_option = element.get("initial_option")
+    items: list[dict[str, Any]] = []
+    for option in element.get("options", []):
+        item: dict[str, Any] = {
+            "text": convert_emoji(option.get("label", "")),
+            "value": option.get("value", ""),
+        }
+        if option.get("value") == initial_option:
+            item["selected"] = True
+        items.append(item)
 
-    return {"buttonList": {"buttons": buttons}}
+    element_id = element.get("id", "")
+    return {
+        "selectionInput": {
+            "name": element_id,
+            "label": convert_emoji(element.get("label", "")),
+            "type": "RADIO_BUTTON" if element.get("type") == "radio_select" else "DROPDOWN",
+            "items": items,
+            "onChangeAction": {
+                "function": endpoint_url or element_id,
+                "parameters": [{"key": "actionId", "value": element_id}],
+            },
+        },
+    }
 
 
 def _convert_button_to_google_button(

--- a/tests/test_gchat_api.py
+++ b/tests/test_gchat_api.py
@@ -291,7 +291,31 @@ class TestEditMessage:
         calls = api.get_calls("PATCH", msg_id)
         assert len(calls) == 1
         assert calls[0]["body"]["text"] is not None
-        assert calls[0]["params"]["updateMask"] == "text"
+        # Editing to text must also clear any stranded card (see regression
+        # test below): updateMask covers both fields and cardsV2 is emptied.
+        assert calls[0]["params"]["updateMask"] == "text,cardsV2"
+
+    @pytest.mark.asyncio
+    async def test_edit_to_text_clears_cards_v2(self):
+        # Regression: GChat renders BOTH the text and the previous cardsV2 if
+        # the card field is left untouched on an edit. Editing a card message
+        # down to plain text must send updateMask "text,cardsV2" with an empty
+        # cardsV2 list so the old card is removed. Matches upstream index.ts
+        # spaces.messages.update (text branch).
+        adapter, api, _ = await _init_adapter()
+        tid = _encode_tid("spaces/ABC123")
+        msg_id = "spaces/ABC123/messages/msg1"
+        api.set_response("PATCH", msg_id, {"name": msg_id})
+
+        await adapter.edit_message(tid, msg_id, "Now just plain text")
+
+        calls = api.get_calls("PATCH", msg_id)
+        assert len(calls) == 1
+        body = calls[0]["body"]
+        assert body["cardsV2"] == []
+        assert body["text"] == "Now just plain text"
+        mask_fields = set(calls[0]["params"]["updateMask"].split(","))
+        assert mask_fields == {"text", "cardsV2"}
 
     @pytest.mark.asyncio
     async def test_edit_message_api_error(self):

--- a/tests/test_gchat_cards.py
+++ b/tests/test_gchat_cards.py
@@ -19,6 +19,7 @@ from chat_sdk.cards import (
     LinkButton,
     Section,
 )
+from chat_sdk.modals import RadioSelect, Select, SelectOption
 from chat_sdk.shared import card_to_fallback_text
 
 # ---------------------------------------------------------------------------
@@ -365,3 +366,173 @@ class TestCardLink:
                 "text": '<a href="https://example.com">Click here</a>',
             },
         }
+
+
+# ---------------------------------------------------------------------------
+# Select / RadioSelect -> selectionInput widgets
+# Port of cards.test.ts "converts select actions to selectionInput ..." tests.
+# ---------------------------------------------------------------------------
+
+
+class TestSelectionInputWidgets:
+    def test_converts_select_actions_to_dropdown_selection_input(self):
+        card = Card(
+            children=[
+                Actions(
+                    [
+                        Select(
+                            id="priority",
+                            label="Priority",
+                            options=[
+                                SelectOption(label="High", value="high", description="Urgent"),
+                                SelectOption(label="Normal", value="normal"),
+                            ],
+                            initial_option="normal",
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        gchat_card = card_to_google_card(
+            card,
+            {"endpoint_url": "https://example.com/api/webhooks/gchat"},
+        )
+
+        widgets = gchat_card["card"]["sections"][0]["widgets"]
+        assert len(widgets) == 1
+        assert widgets[0] == {
+            "selectionInput": {
+                "name": "priority",
+                "label": "Priority",
+                "type": "DROPDOWN",
+                "items": [
+                    {"text": "High", "value": "high"},
+                    {"text": "Normal", "value": "normal", "selected": True},
+                ],
+                "onChangeAction": {
+                    "function": "https://example.com/api/webhooks/gchat",
+                    "parameters": [{"key": "actionId", "value": "priority"}],
+                },
+            },
+        }
+
+    def test_converts_radio_select_actions_to_radio_selection_input(self):
+        card = Card(
+            children=[
+                Actions(
+                    [
+                        RadioSelect(
+                            id="status",
+                            label="Status",
+                            options=[
+                                SelectOption(label="Open", value="open"),
+                                SelectOption(label="Closed", value="closed"),
+                            ],
+                            initial_option="open",
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        gchat_card = card_to_google_card(card)
+        widgets = gchat_card["card"]["sections"][0]["widgets"]
+
+        assert len(widgets) == 1
+        assert widgets[0] == {
+            "selectionInput": {
+                "name": "status",
+                "label": "Status",
+                "type": "RADIO_BUTTON",
+                "items": [
+                    {"text": "Open", "value": "open", "selected": True},
+                    {"text": "Closed", "value": "closed"},
+                ],
+                "onChangeAction": {
+                    # No endpoint URL configured -> function falls back to the id.
+                    "function": "status",
+                    "parameters": [{"key": "actionId", "value": "status"}],
+                },
+            },
+        }
+
+    def test_preserves_action_order_for_mixed_buttons_and_selection_inputs(self):
+        card = Card(
+            children=[
+                Actions(
+                    [
+                        Button(id="refresh", label="Refresh"),
+                        Select(
+                            id="category",
+                            label="Category",
+                            options=[
+                                SelectOption(label="Alpha", value="alpha"),
+                                SelectOption(label="Beta", value="beta"),
+                            ],
+                        ),
+                        LinkButton(url="https://example.com/docs", label="Docs"),
+                        RadioSelect(
+                            id="view",
+                            label="View",
+                            options=[
+                                SelectOption(label="Summary", value="summary"),
+                                SelectOption(label="Detailed", value="detailed"),
+                            ],
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        gchat_card = card_to_google_card(card)
+        widgets = gchat_card["card"]["sections"][0]["widgets"]
+
+        assert len(widgets) == 4
+        assert len(widgets[0]["buttonList"]["buttons"]) == 1
+        assert widgets[0]["buttonList"]["buttons"][0] == {
+            "text": "Refresh",
+            "onClick": {
+                "action": {
+                    "function": "refresh",
+                    "parameters": [{"key": "actionId", "value": "refresh"}],
+                },
+            },
+        }
+        assert widgets[1]["selectionInput"]["name"] == "category"
+        assert widgets[1]["selectionInput"]["type"] == "DROPDOWN"
+        assert widgets[2]["buttonList"]["buttons"] == [
+            {
+                "text": "Docs",
+                "onClick": {
+                    "openLink": {"url": "https://example.com/docs"},
+                },
+            },
+        ]
+        assert widgets[3]["selectionInput"]["name"] == "view"
+        assert widgets[3]["selectionInput"]["type"] == "RADIO_BUTTON"
+
+    def test_selection_input_without_initial_option_marks_none_selected(self):
+        card = Card(
+            children=[
+                Actions(
+                    [
+                        Select(
+                            id="color",
+                            label="Color",
+                            options=[
+                                SelectOption(label="Red", value="red"),
+                                SelectOption(label="Blue", value="blue"),
+                            ],
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        widgets = card_to_google_card(card)["card"]["sections"][0]["widgets"]
+        items = widgets[0]["selectionInput"]["items"]
+        assert items == [
+            {"text": "Red", "value": "red"},
+            {"text": "Blue", "value": "blue"},
+        ]

--- a/tests/test_gchat_webhook.py
+++ b/tests/test_gchat_webhook.py
@@ -508,6 +508,90 @@ class TestHandleWebhook:
         assert response["status"] == 200
 
     @pytest.mark.asyncio
+    async def test_card_click_reads_selection_value_from_form_inputs(self):
+        # Port of index.test.ts "should read selection values from formInputs
+        # when parameters.value is missing". Selection inputs return the chosen
+        # option through formInputs[actionId].stringInputs.value[0], not via
+        # commonEventObject.parameters.value.
+        adapter = _make_adapter()
+        state = _make_mock_state()
+        chat = _make_mock_chat(state)
+        await adapter.initialize(chat)
+
+        event = {
+            "chat": {
+                "buttonClickedPayload": {
+                    "space": {"name": "spaces/ABC123", "type": "ROOM"},
+                    "message": {
+                        "name": "spaces/ABC123/messages/msg1",
+                        "sender": {"name": "users/1", "displayName": "U", "type": "HUMAN"},
+                        "text": "",
+                        "createTime": "2024-01-01T00:00:00Z",
+                    },
+                    "user": {
+                        "name": "users/2",
+                        "displayName": "Clicker",
+                        "type": "HUMAN",
+                        "email": "",
+                    },
+                },
+            },
+            "commonEventObject": {
+                "parameters": {"actionId": "selection"},
+                "formInputs": {
+                    "selection": {"stringInputs": {"value": ["option-1"]}},
+                },
+            },
+        }
+        response = await adapter.handle_webhook(event)
+        assert response["status"] == 200
+        assert chat.process_action.called
+        action_event = chat.process_action.call_args[0][0]
+        assert action_event.action_id == "selection"
+        assert action_event.value == "option-1"
+
+    @pytest.mark.asyncio
+    async def test_card_click_prefers_parameters_value_over_form_inputs(self):
+        # Port of index.test.ts "should prefer parameters.value when both
+        # parameters and formInputs are present" — button value wins.
+        adapter = _make_adapter()
+        state = _make_mock_state()
+        chat = _make_mock_chat(state)
+        await adapter.initialize(chat)
+
+        event = {
+            "chat": {
+                "buttonClickedPayload": {
+                    "space": {"name": "spaces/ABC123", "type": "ROOM"},
+                    "message": {
+                        "name": "spaces/ABC123/messages/msg1",
+                        "sender": {"name": "users/1", "displayName": "U", "type": "HUMAN"},
+                        "text": "",
+                        "createTime": "2024-01-01T00:00:00Z",
+                    },
+                    "user": {
+                        "name": "users/2",
+                        "displayName": "Clicker",
+                        "type": "HUMAN",
+                        "email": "",
+                    },
+                },
+            },
+            "commonEventObject": {
+                "parameters": {"actionId": "selection", "value": "button-value"},
+                "formInputs": {
+                    "selection": {"stringInputs": {"value": ["dropdown-value"]}},
+                },
+            },
+        }
+        response = await adapter.handle_webhook(event)
+        assert response["status"] == 200
+        assert chat.process_action.called
+        action_event = chat.process_action.call_args[0][0]
+        assert action_event.action_id == "selection"
+        assert action_event.value == "button-value"
+
+    @pytest.mark.asyncio
     async def test_non_message_event_returns_200(self):
         adapter = _make_adapter()
         state = _make_mock_state()


### PR DESCRIPTION
Part of the 0.4.30 pre-ship gap-port wave (gchat group). Two pre-existing Google Chat parity gaps ported faithfully from upstream `chat@4.30.0` (`packages/adapter-gchat`). Both are pre-existing, not regressions.

## (A) edit-to-text must clear cardsV2 — LIVE BUG

Editing a card message down to plain text left the original card stranded: Google Chat renders **both** `text` and `cardsV2` when the card field is left untouched on an update.

- **Upstream ref:** `index.ts:1604-1611` — text branch of `spaces.messages.update` sends `updateMask: "text,cardsV2"` with `cardsV2: []`.
- **Fix:** `src/chat_sdk/adapters/google_chat/adapter.py` text-edit path now sends `body={"text": text, "cardsV2": []}` with `params={"updateMask": "text,cardsV2"}` (was `body={"text": text}` / `updateMask: "text"`).
- **Regression test:** `tests/test_gchat_api.py::TestEditMessage::test_edit_to_text_clears_cards_v2` asserts the edit body clears `cardsV2` and the mask covers both fields. The existing `test_edits_text_message` mask assertion was updated to `"text,cardsV2"`.

## (B) Select / RadioSelect → selectionInput widgets + read formInputs

### Render half — `src/chat_sdk/adapters/google_chat/cards.py`
- **Upstream ref:** `cards.ts:275-344` (`convertActionsToWidgets` + `convertSelectionInputToWidget`).
- `_convert_actions_to_widget` (returned a single `buttonList` widget) became the list-returning `_convert_actions_to_widgets`. `select`/`radio_select` children now render as standalone `DROPDOWN`/`RADIO_BUTTON` `selectionInput` widgets with `onChangeAction` (function = endpointUrl or id, parameters carry `actionId`), interleaved between flushed `buttonList` widgets in source order. `initial_option` marks the matching item `selected`.

### Read half — `src/chat_sdk/adapters/google_chat/adapter.py`
- **Upstream ref:** `index.ts:1121-1125` (`handleCardClick`) + `index.ts:1171-1176` (`getFormInputValue`).
- Card-click value now resolves as `parameters.value` first, falling back to `formInputs[actionId].stringInputs.value[0]` via the new `_get_form_input_value` helper. Selection inputs return their chosen option through `formInputs`, not `parameters.value`.

## Tests
- Rendering: dropdown, radio, mixed button/select source-order preservation, no-initial-option (`tests/test_gchat_cards.py::TestSelectionInputWidgets`).
- formInputs value path: read-from-formInputs and prefer-parameters-over-formInputs (`tests/test_gchat_webhook.py`).
- cardsV2-clear regression (`tests/test_gchat_api.py`).
- All bug/regression tests verified to **fail on the pre-fix code** and pass after.

## Gauntlet (from worktree)
- `ruff check`: All checks passed
- `ruff format --check`: 257 files already formatted
- `audit_test_quality.py`: 0 hard failures
- `pyrefly check`: 0 errors
- `pytest`: 4780 passed, 3 skipped

Note: CHANGELOG / UPSTREAM_SYNC deliberately untouched (release docs consolidated separately).