### PR TITLE
fix(teams): ChoiceSet auto-submit fan-out + list_threads/post_channel_message + api_url

### DIFF
--- a/src/chat_sdk/adapters/teams/adapter.py
+++ b/src/chat_sdk/adapters/teams/adapter.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from microsoft_teams.apps import StreamerProtocol
 
 from chat_sdk.adapters.teams.bridge import BridgeHttpAdapter
-from chat_sdk.adapters.teams.cards import card_to_adaptive_card
+from chat_sdk.adapters.teams.cards import AUTO_SUBMIT_ACTION_ID, card_to_adaptive_card
 from chat_sdk.adapters.teams.format_converter import TeamsFormatConverter
 from chat_sdk.adapters.teams.types import (
     TeamsAdapterConfig,
@@ -55,6 +55,8 @@ from chat_sdk.types import (
     FetchResult,
     FileUpload,
     FormattedContent,
+    ListThreadsOptions,
+    ListThreadsResult,
     LockScope,
     Message,
     MessageMetadata,
@@ -63,6 +65,7 @@ from chat_sdk.types import (
     ReactionEvent,
     StreamOptions,
     ThreadInfo,
+    ThreadSummary,
     UserInfo,
     WebhookOptions,
     _parse_iso,
@@ -94,10 +97,10 @@ def _to_app_options(config: TeamsAdapterConfig) -> dict[str, Any]:
 
     Python port of ``packages/adapter-teams/src/config.ts`` ``toAppOptions``
     (synced to ``adapter-teams@chat@4.30.0``). Maps our public
-    ``app_id``/``app_password``/``app_tenant_id``/``federated``/``app_type``
-    fields onto the SDK's ``client_id``/``client_secret``/``tenant_id``/
-    ``managed_identity_client_id`` keys, reading the same ``TEAMS_*`` env-var
-    fallbacks the legacy adapter used.
+    ``app_id``/``app_password``/``app_tenant_id``/``federated``/``app_type``/
+    ``api_url`` fields onto the SDK's ``client_id``/``client_secret``/
+    ``tenant_id``/``managed_identity_client_id``/``service_url`` keys, reading
+    the same ``TEAMS_*`` env-var fallbacks the legacy adapter used.
 
     Returns a dict suitable for ``App(**options)`` minus ``http_server_adapter``
     (the adapter injects the bridge separately). Only keys with a value are
@@ -138,6 +141,11 @@ def _to_app_options(config: TeamsAdapterConfig) -> dict[str, Any]:
 
     managed_identity_client_id = federated.get("client_id") if federated is not None else None
 
+    # Override the Bot Framework service URL for sovereign clouds (GCC-High,
+    # DoD, etc.). Upstream config.ts:38 — ``config.apiUrl ?? TEAMS_API_URL`` —
+    # is fed to the SDK ``AppOptions.serviceUrl``.
+    service_url = config.api_url if config.api_url is not None else os.environ.get("TEAMS_API_URL")
+
     options: dict[str, Any] = {}
     if client_id:
         options["client_id"] = client_id
@@ -147,6 +155,8 @@ def _to_app_options(config: TeamsAdapterConfig) -> dict[str, Any]:
         options["tenant_id"] = tenant_id
     if managed_identity_client_id:
         options["managed_identity_client_id"] = managed_identity_client_id
+    if service_url:
+        options["service_url"] = service_url
     return options
 
 
@@ -963,9 +973,9 @@ class TeamsAdapter:
 
         For plain buttons, ``action_value`` looks like ``{"actionId": "btn_id", "value": "clicked"}``.
         For ChoiceSet (Select/RadioSelect) submissions, it looks like
-        ``{"actionId": "__auto_submit", "my_select": "option_1"}``.
-        In both cases, we pass the full dict (minus ``actionId``) as ``value``
-        so handlers receive all submitted input values.
+        ``{"actionId": "__auto_submit", "my_select": "option_1"}`` and is
+        fanned out into one :meth:`process_action` per input key (upstream
+        index.ts:404-412 + fanOutAutoSubmit index.ts:513-556).
         """
         if not self._chat:
             return
@@ -979,6 +989,11 @@ class TeamsAdapter:
                 service_url=service_url,
             )
         )
+
+        # Auto-submit fan-out: fire on_action for each input value.
+        if action_value.get("actionId") == AUTO_SUBMIT_ACTION_ID:
+            self._fan_out_auto_submit(action_value, activity, thread_id, options)
+            return
 
         action_id, submitted_values = self._extract_action_values(action_value)
 
@@ -1023,6 +1038,11 @@ class TeamsAdapter:
             )
         )
 
+        # Auto-submit fan-out: fire on_action for each input value.
+        if action_data.get("actionId") == AUTO_SUBMIT_ACTION_ID:
+            self._fan_out_auto_submit(action_data, activity, thread_id, options)
+            return
+
         action_id, submitted_values = self._extract_action_values(action_data)
 
         from_user = activity.get("from", {})
@@ -1045,6 +1065,60 @@ class TeamsAdapter:
             ),
             options,
         )
+
+    def _fan_out_auto_submit(
+        self,
+        payload: dict[str, Any],
+        activity: dict[str, Any],
+        thread_id: str,
+        options: WebhookOptions | None = None,
+    ) -> None:
+        """Fan out an auto-submit payload into individual ``on_action`` calls.
+
+        Called when the sentinel ``__auto_submit`` action ID is detected on a
+        ChoiceSet (Select / RadioSelect) submission. Each input key/value pair
+        is dispatched as a separate :meth:`process_action` so a handler
+        registered as ``on_action(input_key)`` fires once per submitted input.
+
+        Python port of upstream ``fanOutAutoSubmit`` (adapter-teams/src/index.ts:513-556).
+        Transport keys (``actionId``, ``msteams``) injected by the SDK card
+        renderer / Teams infra are filtered out; non-string values map to
+        ``None`` (upstream ``typeof val === "string" ? val : undefined``).
+        """
+        if not self._chat:
+            return
+
+        entries = [(k, v) for k, v in payload.items() if k not in self._ACTION_TRANSPORT_KEYS]
+
+        self._logger.debug(
+            "Auto-submit fan-out",
+            {"inputCount": len(entries), "keys": [k for k, _ in entries]},
+        )
+
+        from_user = activity.get("from", {})
+        user = Author(
+            user_id=from_user.get("id", "unknown"),
+            user_name=from_user.get("name", "unknown"),
+            full_name=from_user.get("name", "unknown"),
+            is_bot=False,
+            is_me=False,
+        )
+        message_id = activity.get("replyToId") or activity.get("id", "")
+
+        for key, val in entries:
+            self._chat.process_action(
+                ActionEvent(
+                    action_id=key,
+                    value=val if isinstance(val, str) else None,
+                    user=user,
+                    message_id=message_id,
+                    thread_id=thread_id,
+                    thread=None,  # pyrefly: ignore[bad-argument-type]  # filled in by Chat
+                    adapter=self,
+                    raw=activity,
+                ),
+                options,
+            )
 
     def _handle_reaction_activity(
         self,
@@ -1975,6 +2049,184 @@ class TeamsAdapter:
         except Exception as error:
             self._logger.error("Teams Graph API: fetchChannelMessages error", {"error": str(error)})
             raise
+
+    async def list_threads(
+        self,
+        channel_id: str,
+        options: ListThreadsOptions | dict[str, Any] | None = None,
+    ) -> ListThreadsResult:
+        """List threads in a Teams channel (or chat) via Microsoft Graph API.
+
+        Python port of upstream ``GraphReader.listThreads``
+        (adapter-teams/src/graph-api.ts:367-516, surfaced by index.ts:1357).
+        Each top-level Graph message becomes a :class:`ThreadSummary` whose
+        ``id`` is the per-message thread ID (``{baseConversationId};messageid=
+        {msg.id}``) and whose ``root_message`` is the mapped message. The
+        channel path additionally carries ``last_reply_at`` (the message's
+        ``lastModifiedDateTime``); the chat path does not.
+        """
+        if options is None:
+            options = ListThreadsOptions()
+        elif isinstance(options, dict):
+            options = ListThreadsOptions(**options)
+
+        decoded = self.decode_thread_id(channel_id)
+        conversation_id = decoded.conversation_id
+        service_url = decoded.service_url
+        base_conversation_id = MESSAGEID_STRIP_PATTERN.sub("", conversation_id)
+        limit = options.limit if options.limit is not None else 50
+
+        try:
+            graph_context = await self._get_graph_context(base_conversation_id)
+            context_type = graph_context.get("type") if graph_context else None
+
+            self._logger.debug(
+                "Teams Graph API: listThreads",
+                {
+                    "conversationId": base_conversation_id,
+                    "contextType": context_type or "none",
+                    "limit": limit,
+                },
+            )
+
+            threads: list[ThreadSummary] = []
+
+            if graph_context and context_type != "dm":
+                channel_context = cast(TeamsChannelContext, graph_context)
+                graph_messages = await self._graph_list_channel_messages(
+                    channel_context["team_id"],
+                    channel_context["channel_id"],
+                    limit=limit,
+                )
+                for msg in graph_messages:
+                    if not msg.get("id"):
+                        continue
+                    thread_id = self.encode_thread_id(
+                        TeamsThreadId(
+                            conversation_id=f"{base_conversation_id};messageid={msg['id']}",
+                            service_url=service_url,
+                        )
+                    )
+                    last_modified = msg.get("lastModifiedDateTime")
+                    threads.append(
+                        ThreadSummary(
+                            id=thread_id,
+                            root_message=self._map_graph_message(msg, thread_id),
+                            last_reply_at=(_parse_iso(last_modified) if last_modified else None),
+                        )
+                    )
+            else:
+                chat_id = self._chat_id_from_context(graph_context, base_conversation_id)
+                graph_messages = await self._graph_list_chat_messages(
+                    chat_id,
+                    {"$top": limit, "$orderby": "createdDateTime desc"},
+                )
+                for msg in graph_messages:
+                    if not msg.get("id"):
+                        continue
+                    thread_id = self.encode_thread_id(
+                        TeamsThreadId(
+                            conversation_id=f"{base_conversation_id};messageid={msg['id']}",
+                            service_url=service_url,
+                        )
+                    )
+                    threads.append(
+                        ThreadSummary(
+                            id=thread_id,
+                            root_message=self._map_graph_message(msg, thread_id),
+                        )
+                    )
+
+            self._logger.debug("Teams Graph API: listThreads result", {"threadCount": len(threads)})
+            return ListThreadsResult(threads=threads)
+
+        except Exception as error:
+            self._logger.error("Teams Graph API: listThreads error", {"error": str(error)})
+            raise
+
+    async def post_channel_message(
+        self,
+        channel_id: str,
+        message: AdapterPostableMessage,
+    ) -> RawMessage:
+        """Post a message to a Teams channel's base conversation (top-level).
+
+        Python port of upstream ``postChannelMessage``
+        (adapter-teams/src/index.ts:1368-1430). The ``;messageid=`` suffix is
+        stripped so the activity lands on the base channel conversation rather
+        than threaded under a specific root message. Supports card, file, and
+        plain-text postable shapes, mirroring :meth:`post_message`.
+        """
+        decoded = self.decode_thread_id(channel_id)
+        base_conversation_id = MESSAGEID_STRIP_PATTERN.sub("", decoded.conversation_id)
+
+        files = extract_files(message)
+        file_attachments = await self._files_to_attachments(files) if files else []
+
+        card = extract_card(message)
+        if card:
+            adaptive_card = card_to_adaptive_card(card)
+            activity_payload: dict[str, Any] = {
+                "type": "message",
+                "attachments": [
+                    {
+                        "contentType": "application/vnd.microsoft.card.adaptive",
+                        "content": adaptive_card,
+                    },
+                    *file_attachments,
+                ],
+            }
+
+            try:
+                self._point_app_api_at(decoded.service_url)
+                sent = await self._app.send(
+                    base_conversation_id,
+                    self._message_activity_input(activity_payload),
+                )
+                return RawMessage(
+                    id=getattr(sent, "id", "") or "",
+                    thread_id=channel_id,
+                    raw=activity_payload,
+                )
+            except Exception as error:
+                self._logger.error(
+                    "Teams API: postChannelMessage failed",
+                    {"conversationId": base_conversation_id, "error": str(error)},
+                )
+                _handle_teams_error(error, "postChannelMessage")
+                raise  # unreachable: _handle_teams_error always raises
+
+        text = convert_emoji_placeholders(
+            self._format_converter.render_postable(message),
+            "teams",
+        )
+        activity_payload = {
+            "type": "message",
+            "text": text,
+            "textFormat": "markdown",
+        }
+        if file_attachments:
+            activity_payload["attachments"] = file_attachments
+
+        try:
+            self._point_app_api_at(decoded.service_url)
+            sent = await self._app.send(
+                base_conversation_id,
+                self._message_activity_input(activity_payload),
+            )
+            self._logger.debug("Teams API: postChannelMessage response", {"messageId": getattr(sent, "id", None)})
+            return RawMessage(
+                id=getattr(sent, "id", "") or "",
+                thread_id=channel_id,
+                raw=activity_payload,
+            )
+        except Exception as error:
+            self._logger.error(
+                "Teams API: postChannelMessage failed",
+                {"conversationId": base_conversation_id, "error": str(error)},
+            )
+            _handle_teams_error(error, "postChannelMessage")
+            raise  # unreachable: _handle_teams_error always raises
 
     async def fetch_thread(self, thread_id: str) -> ThreadInfo:
         """Fetch basic thread info for a Teams conversation."""

--- a/src/chat_sdk/adapters/teams/types.py
+++ b/src/chat_sdk/adapters/teams/types.py
@@ -54,6 +54,9 @@ class TeamsAdapterConfig:
     See: https://learn.microsoft.com/en-us/microsoftteams/platform/bots/
     """
 
+    # Override the Teams Bot Framework service URL (e.g. for GCC-High /
+    # sovereign-cloud environments). Defaults to TEAMS_API_URL env var.
+    api_url: str | None = None
     # Microsoft App ID. Defaults to TEAMS_APP_ID env var.
     app_id: str | None = None
     # Microsoft App Password. Defaults to TEAMS_APP_PASSWORD env var.

--- a/tests/test_teams_cards.py
+++ b/tests/test_teams_cards.py
@@ -495,11 +495,15 @@ class TestTeamsCardInputEndToEnd:
         }
         await adapter._handle_message_activity(activity)
 
-        # 3. Verify process_action received the selected values
+        # 3. The __auto_submit sentinel fans out into one process_action per
+        #    input key (adapter-teams/src/index.ts:404-471 + fanOutAutoSubmit),
+        #    so a handler registered as on_action("color_select") fires with the
+        #    selected value — the sentinel itself is never surfaced as an action ID.
         mock_chat.process_action.assert_called_once()
         action_event = mock_chat.process_action.call_args[0][0]
-        assert action_event.action_id == AUTO_SUBMIT_ACTION_ID
-        assert action_event.value == {"color_select": "blue"}
+        assert action_event.action_id == "color_select"
+        assert action_event.action_id != AUTO_SUBMIT_ACTION_ID
+        assert action_event.value == "blue"
         assert action_event.user.user_id == "user-1"
 
     async def test_button_click_still_works(self):

--- a/tests/test_teams_coverage.py
+++ b/tests/test_teams_coverage.py
@@ -2026,3 +2026,189 @@ class TestFetchMessages403:
 
         with pytest.raises(APE):
             await adapter.fetch_messages(tid)
+
+
+# ---------------------------------------------------------------------------
+# list_threads (Graph API) — channel + chat paths
+# ---------------------------------------------------------------------------
+
+
+class TestListThreads:
+    async def test_channel_path_wraps_each_message_as_thread(self):
+        """Channel context → one ThreadSummary per top-level message, each with a
+        per-message thread ID (``;messageid=`` suffix) and ``last_reply_at``.
+
+        Mirrors upstream GraphReader.listThreads channel branch (graph-api.ts:389-449).
+        """
+        adapter = _make_adapter(logger=_make_logger(), app_id="bot-app-id")
+        state = _make_mock_state()
+        state._cache["teams:channelContext:19:chan@thread.tacv2"] = json.dumps(
+            {"type": "channel", "team_id": "team-1", "channel_id": "19:chan@thread.tacv2"}
+        )
+        chat = _make_mock_chat(state)
+        await adapter.initialize(chat)
+
+        async def fake_channel_list(team_id: str, channel_id: str, limit: int = 50):
+            assert team_id == "team-1"
+            assert channel_id == "19:chan@thread.tacv2"
+            return [
+                {
+                    "id": "100",
+                    "createdDateTime": "2024-06-01T12:00:00Z",
+                    "lastModifiedDateTime": "2024-06-01T12:05:00Z",
+                    "body": {"contentType": "text", "content": "First"},
+                    "from": {"user": {"id": "u1", "displayName": "Alice"}},
+                },
+                {
+                    "id": "200",
+                    "createdDateTime": "2024-06-01T11:00:00Z",
+                    "body": {"contentType": "text", "content": "Second"},
+                    "from": {"user": {"id": "u2", "displayName": "Bob"}},
+                },
+                {"from": {"user": {"id": "u3"}}},  # no id → skipped
+            ]
+
+        adapter._graph_list_channel_messages = fake_channel_list  # type: ignore[method-assign]
+
+        channel_id = adapter.encode_thread_id(
+            TeamsThreadId(
+                conversation_id="19:chan@thread.tacv2",
+                service_url="https://smba.trafficmanager.net/teams/",
+            )
+        )
+        result = await adapter.list_threads(channel_id)
+
+        assert len(result.threads) == 2
+        first = result.threads[0]
+        # Root message text mapped from the Graph body.
+        assert first.root_message.text == "First"
+        # Per-message thread ID embeds messageid=100, distinct from the channel id.
+        decoded = adapter.decode_thread_id(first.id)
+        assert decoded.conversation_id == "19:chan@thread.tacv2;messageid=100"
+        assert first.id != channel_id
+        # last_reply_at from lastModifiedDateTime (channel path only).
+        assert first.last_reply_at is not None
+        assert first.last_reply_at.year == 2024
+        assert result.threads[1].last_reply_at is None  # no lastModifiedDateTime
+
+    async def test_chat_path_lists_chat_messages_without_last_reply(self):
+        """No channel context → chat-messages path; ThreadSummaries carry no
+        ``last_reply_at`` (graph-api.ts:450-505)."""
+        adapter = _make_adapter(logger=_make_logger(), app_id="bot-app-id")
+        state = _make_mock_state()
+        chat = _make_mock_chat(state)
+        await adapter.initialize(chat)
+
+        captured_params: list[Any] = []
+
+        async def fake_chat_list(chat_id: str, params: Any):
+            captured_params.append(params)
+            return [
+                {
+                    "id": "300",
+                    "createdDateTime": "2024-06-02T09:00:00Z",
+                    "body": {"contentType": "text", "content": "Chat msg"},
+                    "from": {"user": {"id": "u9", "displayName": "Carol"}},
+                }
+            ]
+
+        adapter._graph_list_chat_messages = fake_chat_list  # type: ignore[method-assign]
+
+        channel_id = adapter.encode_thread_id(
+            TeamsThreadId(
+                conversation_id="19:group@thread.v2",
+                service_url="https://smba.trafficmanager.net/teams/",
+            )
+        )
+        result = await adapter.list_threads(channel_id, {"limit": 10})
+
+        assert len(result.threads) == 1
+        summary = result.threads[0]
+        assert summary.root_message.text == "Chat msg"
+        assert summary.last_reply_at is None
+        decoded = adapter.decode_thread_id(summary.id)
+        assert decoded.conversation_id == "19:group@thread.v2;messageid=300"
+        # Honors the limit + descending order Graph query (graph-api.ts:452-456).
+        assert captured_params[0]["$top"] == 10
+        assert captured_params[0]["$orderby"] == "createdDateTime desc"
+
+    async def test_propagates_graph_errors(self):
+        adapter = _make_adapter(logger=_make_logger())
+        state = _make_mock_state()
+        chat = _make_mock_chat(state)
+        await adapter.initialize(chat)
+
+        async def boom(chat_id: str, params: Any):
+            raise NetworkError("teams", "Graph API error: 500")
+
+        adapter._graph_list_chat_messages = boom  # type: ignore[method-assign]
+
+        channel_id = adapter.encode_thread_id(
+            TeamsThreadId(
+                conversation_id="19:group@thread.v2",
+                service_url="https://smba.trafficmanager.net/teams/",
+            )
+        )
+        with pytest.raises(NetworkError):
+            await adapter.list_threads(channel_id)
+
+
+# ---------------------------------------------------------------------------
+# post_channel_message — text + card to the base conversation
+# ---------------------------------------------------------------------------
+
+
+class TestPostChannelMessage:
+    async def test_text_posts_to_base_conversation(self):
+        """Strips ``;messageid=`` so the activity lands on the base channel
+        conversation, not threaded under a root message (index.ts:1372-1376)."""
+        adapter = _make_adapter(logger=_make_logger())
+        send = _mock_app_send(adapter, "ch-text-1")
+
+        channel_id = adapter.encode_thread_id(
+            TeamsThreadId(
+                conversation_id="19:chan@thread.tacv2;messageid=999",
+                service_url="https://smba.trafficmanager.net/teams/",
+            )
+        )
+        result = await adapter.post_channel_message(channel_id, {"markdown": "Hello **channel**"})
+
+        assert result.id == "ch-text-1"
+        # threadId echoes the input channel_id (index.ts:1422).
+        assert result.thread_id == channel_id
+        # Sent to the base conversation — the messageid suffix is stripped.
+        assert send.call_args.args[0] == "19:chan@thread.tacv2"
+
+    async def test_card_posts_adaptive_card_to_base_conversation(self):
+        adapter = _make_adapter(logger=_make_logger())
+        send = _mock_app_send(adapter, "ch-card-1")
+
+        channel_id = adapter.encode_thread_id(
+            TeamsThreadId(
+                conversation_id="19:chan@thread.tacv2",
+                service_url="https://smba.trafficmanager.net/teams/",
+            )
+        )
+        result = await adapter.post_channel_message(
+            channel_id,
+            {"card": {"header": {"title": "Notice"}, "body": [{"type": "text", "content": "Body"}]}},
+        )
+
+        assert result.id == "ch-card-1"
+        activity = send.call_args.args[1]
+        dumped = activity.model_dump(by_alias=True, exclude_none=True)
+        assert dumped["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"
+
+    async def test_send_failure_raises(self):
+        adapter = _make_adapter(logger=_make_logger())
+        send = _mock_app_send(adapter)
+        send.side_effect = Exception("connection failed")
+
+        channel_id = adapter.encode_thread_id(
+            TeamsThreadId(
+                conversation_id="19:chan@thread.tacv2",
+                service_url="https://smba.trafficmanager.net/teams/",
+            )
+        )
+        with pytest.raises(NetworkError):
+            await adapter.post_channel_message(channel_id, {"markdown": "fail"})

--- a/tests/test_teams_extended.py
+++ b/tests/test_teams_extended.py
@@ -530,6 +530,46 @@ class TestToAppOptions:
                 )
             )
 
+    def test_api_url_sets_service_url(self):
+        """``api_url`` threads into ``service_url`` for sovereign clouds (config.ts:38).
+
+        GCC-High / DoD tenants run the Bot Framework on a different host; upstream
+        feeds ``config.apiUrl`` to the SDK ``AppOptions.serviceUrl`` so all outbound
+        calls target that endpoint instead of the global default.
+        """
+        opts = _to_app_options(
+            TeamsAdapterConfig(
+                app_id="app-1",
+                app_password="secret-1",
+                api_url="https://smba.infra.gov.teams.microsoft.us/",
+            )
+        )
+        assert opts["service_url"] == "https://smba.infra.gov.teams.microsoft.us/"
+
+    def test_no_api_url_omits_service_url(self):
+        """Absent ``api_url``/``TEAMS_API_URL``, ``service_url`` is left unset so the
+        SDK applies its own global default rather than receiving an empty string."""
+        opts = _to_app_options(TeamsAdapterConfig(app_id="app-1", app_password="secret-1"))
+        assert "service_url" not in opts
+
+    def test_api_url_env_fallback(self, monkeypatch):
+        """``TEAMS_API_URL`` env var is the fallback when ``api_url`` is unset."""
+        monkeypatch.setenv("TEAMS_API_URL", "https://smba.gov.teams.microsoft.us/")
+        opts = _to_app_options(TeamsAdapterConfig(app_id="app-1", app_password="secret-1"))
+        assert opts["service_url"] == "https://smba.gov.teams.microsoft.us/"
+
+    def test_api_url_config_overrides_env(self, monkeypatch):
+        """Explicit ``api_url`` wins over ``TEAMS_API_URL`` (config field precedence)."""
+        monkeypatch.setenv("TEAMS_API_URL", "https://env.example.us/")
+        opts = _to_app_options(
+            TeamsAdapterConfig(
+                app_id="app-1",
+                app_password="secret-1",
+                api_url="https://explicit.example.us/",
+            )
+        )
+        assert opts["service_url"] == "https://explicit.example.us/"
+
 
 # ---------------------------------------------------------------------------
 # Message ID patterns
@@ -672,6 +712,138 @@ class TestMessageAction:
         response = await adapter.handle_webhook(request)
         assert response["status"] == 200
         assert chat.process_action.called
+
+
+# ---------------------------------------------------------------------------
+# ChoiceSet auto-submit fan-out (regression for single-dispatch bug)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSubmitFanOut:
+    """ChoiceSet (Select/RadioSelect) submissions carry the ``__auto_submit``
+    sentinel action ID and a per-input dict, e.g.
+    ``{"actionId": "__auto_submit", "color": "red", "size": "L"}``.
+
+    Upstream (adapter-teams/src/index.ts:404-471 + fanOutAutoSubmit 513-556)
+    fans this out into ONE ``chat.processAction`` per input key so a handler
+    registered as ``on_action("color")`` fires. The pre-fix Python adapter
+    dispatched a SINGLE action with ``action_id="__auto_submit"`` and the full
+    dict as ``value`` — these tests fail on that code.
+    """
+
+    def test_message_action_fans_out_per_input_key(self):
+        adapter = _make_adapter(logger=_make_logger())
+        chat = _make_mock_chat()
+        adapter._chat = chat
+
+        activity = {
+            "type": "message",
+            "id": "msg-1",
+            "from": {"id": "user-1", "name": "Alice"},
+            "conversation": {"id": "19:abc@thread.tacv2"},
+            "serviceUrl": "https://smba.trafficmanager.net/teams/",
+        }
+        action_value = {"actionId": "__auto_submit", "color": "red", "size": "L"}
+
+        adapter._handle_message_action(activity, action_value)
+
+        # One process_action per input key (regression: pre-fix dispatched once).
+        assert chat.process_action.call_count == 2
+        dispatched = {call.args[0].action_id: call.args[0].value for call in chat.process_action.call_args_list}
+        assert dispatched == {"color": "red", "size": "L"}
+        # The sentinel must never leak through as an action ID.
+        assert "__auto_submit" not in dispatched
+
+    async def test_adaptive_card_action_fans_out_per_input_key(self):
+        adapter = _make_adapter(logger=_make_logger())
+        chat = _make_mock_chat()
+        adapter._chat = chat
+
+        activity = {
+            "type": "invoke",
+            "id": "inv-1",
+            "from": {"id": "user-2", "name": "Bob"},
+            "conversation": {"id": "19:def@thread.tacv2"},
+            "serviceUrl": "https://smba.trafficmanager.net/teams/",
+        }
+        action_data = {"actionId": "__auto_submit", "priority": "high"}
+
+        await adapter._handle_adaptive_card_action(activity, action_data)
+
+        assert chat.process_action.call_count == 1
+        event = chat.process_action.call_args.args[0]
+        assert event.action_id == "priority"
+        assert event.value == "high"
+
+    def test_fan_out_drops_msteams_transport_key(self):
+        """The ``msteams`` transport key injected by Teams infra is not user input
+        and must be filtered out of the fan-out (upstream filters actionId + msteams)."""
+        adapter = _make_adapter(logger=_make_logger())
+        chat = _make_mock_chat()
+        adapter._chat = chat
+
+        activity = {
+            "id": "msg-1",
+            "from": {"id": "u", "name": "U"},
+            "conversation": {"id": "19:abc@thread.tacv2"},
+            "serviceUrl": "https://smba.trafficmanager.net/teams/",
+        }
+        action_value = {
+            "actionId": "__auto_submit",
+            "msteams": {"type": "messageBack"},
+            "topic": "billing",
+        }
+
+        adapter._handle_message_action(activity, action_value)
+
+        assert chat.process_action.call_count == 1
+        event = chat.process_action.call_args.args[0]
+        assert event.action_id == "topic"
+        assert event.value == "billing"
+
+    def test_fan_out_non_string_value_becomes_none(self):
+        """Non-string input values map to ``None`` per upstream
+        ``typeof val === "string" ? val : undefined`` (index.ts:551)."""
+        adapter = _make_adapter(logger=_make_logger())
+        chat = _make_mock_chat()
+        adapter._chat = chat
+
+        activity = {
+            "id": "msg-1",
+            "from": {"id": "u", "name": "U"},
+            "conversation": {"id": "19:abc@thread.tacv2"},
+            "serviceUrl": "https://smba.trafficmanager.net/teams/",
+        }
+        action_value = {"actionId": "__auto_submit", "flags": ["a", "b"]}
+
+        adapter._handle_message_action(activity, action_value)
+
+        assert chat.process_action.call_count == 1
+        event = chat.process_action.call_args.args[0]
+        assert event.action_id == "flags"
+        assert event.value is None
+
+    def test_plain_button_not_fanned_out(self):
+        """A plain Action.Submit button (no ``__auto_submit`` sentinel) keeps the
+        single-dispatch path with its own action ID — fan-out must not regress it."""
+        adapter = _make_adapter(logger=_make_logger())
+        chat = _make_mock_chat()
+        adapter._chat = chat
+
+        activity = {
+            "id": "msg-1",
+            "from": {"id": "u", "name": "U"},
+            "conversation": {"id": "19:abc@thread.tacv2"},
+            "serviceUrl": "https://smba.trafficmanager.net/teams/",
+        }
+        action_value = {"actionId": "approve_btn", "value": "yes"}
+
+        adapter._handle_message_action(activity, action_value)
+
+        assert chat.process_action.call_count == 1
+        event = chat.process_action.call_args.args[0]
+        assert event.action_id == "approve_btn"
+        assert event.value == "yes"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Ports three pre-existing Teams parity gaps the 0.4.30 upstream-parity audit found (all pre-existing, not regressions), from upstream `chat@4.30.0` (`packages/adapter-teams`). Code + tests only; release docs (CHANGELOG / UPSTREAM_SYNC) are consolidated separately.

## (A) ChoiceSet auto-submit fan-out [contract break]
On detecting the `__auto_submit` sentinel (`cards.py` `AUTO_SUBMIT_ACTION_ID`), both `_handle_message_action` and `_handle_adaptive_card_action` now fan out into one `chat.process_action` **per input key** (`action_id=key`, `value=str` or `None` for non-string values), instead of a single dispatch carrying `action_id="__auto_submit"` and the full dict. A handler registered as `on_action(input_key)` now fires for ChoiceSet (Select / RadioSelect) submissions. The outbound `__auto_submit` sentinel is preserved.

Upstream refs: `index.ts:404-471` (both handlers) + `fanOutAutoSubmit` (`index.ts:513-556`).

Regression tests assert one `process_action` per input key and **fail on the pre-fix single-dispatch code** (verified). The pre-existing `test_select_submit_round_trip` had encoded the buggy contract (`action_id == __auto_submit`); it is updated to the corrected fan-out behavior.

## (B) list_threads + post_channel_message
Both previously fell through to the base `Adapter`, raising `ChatNotImplementedError`.
- `list_threads` wraps each top-level Graph message as a `ThreadSummary` with a per-message thread id (`{base};messageid={id}`) and, on the channel path, `last_reply_at` (`graph-api.ts:367-516`, surfaced by `index.ts:1357`). Reuses the existing `_get_graph_context` / `_graph_list_channel_messages` / `_graph_list_chat_messages` / `_map_graph_message` Graph patterns.
- `post_channel_message` strips the `;messageid=` suffix so the activity lands on the base channel conversation, and sends card / file / text (`index.ts:1368-1430`), mirroring `post_message`.

## (C) api_url / TEAMS_API_URL config
New `TeamsAdapterConfig.api_url` field (+ `TEAMS_API_URL` env fallback) threaded into `_to_app_options` as the SDK `service_url` for GCC-High / sovereign clouds (`config.ts:38`, `types.ts:22`). Matches the already-ported Telegram `api_url` pattern.

## Gauntlet (from worktree)
- `ruff check` — All checks passed
- `ruff format --check` — 257 files already formatted
- `audit_test_quality.py` — 0 hard failures (39 warnings / 18 groups, unchanged from baseline)
- `pyrefly check` — 0 errors
- `pytest tests/` — 4788 passed, 3 skipped (+15 new tests, 1 updated)

All three gaps are confined to `src/chat_sdk/adapters/teams/`.