### PR TITLE
feat(teams): webhook primitive subpath (chat@4.31 8c71411)

### DIFF
--- a/src/chat_sdk/adapters/teams/webhook/__init__.py
+++ b/src/chat_sdk/adapters/teams/webhook/__init__.py
@@ -1,0 +1,117 @@
+"""Teams webhook primitives — a lightweight, runtime-free subpath.
+
+Port of ``packages/adapter-teams/src/webhook`` (chat@4.31, commit 8c71411),
+exposed upstream as ``@chat-adapter/teams/webhook``. Provides primitives for
+classifying an inbound Bot Framework activity into typed, discriminated
+payloads, plus continuation / user / attachment extraction and bot-mention
+detection — without the full Teams adapter, the ``microsoft_teams`` SDK,
+chat state, dedupe, locks, or subscriptions.
+
+Parse-ONLY: these primitives never verify JWTs and never make outbound HTTP
+requests. Importing this module never imports ``microsoft_teams``, HTTP
+clients, or the high-level :mod:`chat_sdk.adapters.teams.adapter`.
+
+Wire boundary: typed results are ``snake_case`` dataclasses; the original
+camelCase Bot Framework activity is preserved verbatim on each payload's
+``raw`` field (``channelData.teamsChannelId``, ``replyToId``, ``aadObjectId``,
+``tenantId``, ...).
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from chat_sdk.adapters.teams.webhook.continuation import (
+    extract_teams_attachments,
+    extract_teams_continuation,
+    extract_teams_user,
+    is_teams_mention,
+)
+from chat_sdk.adapters.teams.webhook.parse import parse_teams_webhook_body
+from chat_sdk.adapters.teams.webhook.types import (
+    TeamsActivity,
+    TeamsCardActionPayload,
+    TeamsContinuation,
+    TeamsConversationUpdatePayload,
+    TeamsDialogOpenPayload,
+    TeamsDialogSubmitPayload,
+    TeamsInstallationUpdatePayload,
+    TeamsMessagePayload,
+    TeamsMessageReactionPayload,
+    TeamsParseOptions,
+    TeamsUnsupportedPayload,
+    TeamsWebhookAttachment,
+    TeamsWebhookError,
+    TeamsWebhookParseError,
+    TeamsWebhookPayload,
+    TeamsWebhookUser,
+)
+
+
+async def read_teams_request_body(request: Any) -> str:
+    """Read the raw body from a duck-typed request object.
+
+    Python stand-in for the Fetch API's ``await request.text()`` used by the
+    upstream ``readTeamsWebhook`` helper. Supports:
+
+    - ``request.text`` as an (async or sync) method or plain attribute
+    - ``request.body`` as an (async or sync) method, awaitable, bytes, or str
+    - falling back to ``str(request)``
+
+    Bytes are decoded as UTF-8.
+    """
+    text_attr = getattr(request, "text", None)
+    if text_attr is not None:
+        if callable(text_attr):
+            result = text_attr()
+            text_attr = await result if inspect.isawaitable(result) else result
+        return text_attr.decode("utf-8") if isinstance(text_attr, (bytes, bytearray)) else str(text_attr)
+    raw = getattr(request, "body", None)
+    if raw is not None:
+        if callable(raw):
+            raw = raw()
+        if inspect.isawaitable(raw):
+            raw = await raw
+        return raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw)
+    return str(request)
+
+
+async def read_teams_webhook(
+    request: Any,
+    options: TeamsParseOptions | None = None,
+) -> TeamsWebhookPayload:
+    """Read a request body and classify it — no JWT verification.
+
+    Port of upstream ``readTeamsWebhook``: reads ``await request.text()`` then
+    delegates to :func:`parse_teams_webhook_body`.
+    """
+    body = await read_teams_request_body(request)
+    return parse_teams_webhook_body(body, options)
+
+
+__all__ = [
+    "TeamsActivity",
+    "TeamsCardActionPayload",
+    "TeamsContinuation",
+    "TeamsConversationUpdatePayload",
+    "TeamsDialogOpenPayload",
+    "TeamsDialogSubmitPayload",
+    "TeamsInstallationUpdatePayload",
+    "TeamsMessagePayload",
+    "TeamsMessageReactionPayload",
+    "TeamsParseOptions",
+    "TeamsUnsupportedPayload",
+    "TeamsWebhookAttachment",
+    "TeamsWebhookError",
+    "TeamsWebhookParseError",
+    "TeamsWebhookPayload",
+    "TeamsWebhookUser",
+    "extract_teams_attachments",
+    "extract_teams_continuation",
+    "extract_teams_user",
+    "is_teams_mention",
+    "parse_teams_webhook_body",
+    "read_teams_request_body",
+    "read_teams_webhook",
+]

--- a/src/chat_sdk/adapters/teams/webhook/continuation.py
+++ b/src/chat_sdk/adapters/teams/webhook/continuation.py
@@ -41,9 +41,11 @@ def extract_teams_continuation(activity: TeamsActivity) -> TeamsContinuation:
 
     ``conversation_id`` / ``service_url`` default to ``""`` (upstream ``?? ""``)
     so the continuation always carries the two fields a reply needs; the rest
-    are populated only when present, applying the same channelData fallbacks
-    as upstream (``channel.id`` then ``teamsChannelId``; ``team.id`` then
-    ``teamsTeamId``; ``conversation.tenantId`` then ``tenant.id``).
+    are populated only when present. Upstream builds the result with an object
+    spread where the *later* source wins when both are present, so the
+    channelData-native fields take precedence: ``teamsChannelId`` over
+    ``channel.id``; ``teamsTeamId`` over ``team.id``; ``channelData.tenant.id``
+    over ``conversation.tenantId``.
     """
     channel_data = _record(activity.get("channelData")) or {}
     conversation = _record(activity.get("conversation")) or {}
@@ -51,17 +53,17 @@ def extract_teams_continuation(activity: TeamsActivity) -> TeamsContinuation:
     team = _record(channel_data.get("team")) or {}
     tenant = _record(channel_data.get("tenant")) or {}
 
-    channel_id = _opt_str(channel.get("id"))
+    channel_id = _opt_str(channel_data.get("teamsChannelId"))
     if channel_id is None:
-        channel_id = _opt_str(channel_data.get("teamsChannelId"))
+        channel_id = _opt_str(channel.get("id"))
 
-    team_id = _opt_str(team.get("id"))
+    team_id = _opt_str(channel_data.get("teamsTeamId"))
     if team_id is None:
-        team_id = _opt_str(channel_data.get("teamsTeamId"))
+        team_id = _opt_str(team.get("id"))
 
-    tenant_id = _opt_str(conversation.get("tenantId"))
+    tenant_id = _opt_str(tenant.get("id"))
     if tenant_id is None:
-        tenant_id = _opt_str(tenant.get("id"))
+        tenant_id = _opt_str(conversation.get("tenantId"))
 
     conversation_id = conversation.get("id")
     service_url = activity.get("serviceUrl")

--- a/src/chat_sdk/adapters/teams/webhook/continuation.py
+++ b/src/chat_sdk/adapters/teams/webhook/continuation.py
@@ -1,0 +1,163 @@
+"""Continuation / extraction helpers for the Teams webhook primitives.
+
+Port of ``packages/adapter-teams/src/webhook/continuation.ts`` (chat@4.31,
+commit 8c71411). Pulls provider-native reply data, the acting user, message
+attachments, and bot-mention state out of a raw Bot Framework activity.
+
+These helpers are SDK-free: they operate on plain dicts (the camelCase wire
+shape) using membership / ``is not None`` checks — never truthiness ``or``
+fallbacks that would coerce ``""``/``0``/``False`` into the wrong branch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chat_sdk.adapters.teams.webhook.types import (
+    TeamsActivity,
+    TeamsContinuation,
+    TeamsWebhookAttachment,
+    TeamsWebhookUser,
+)
+
+
+def _record(value: Any) -> dict[str, Any] | None:
+    """Return ``value`` when it is a dict, else ``None`` (optional chaining)."""
+    return value if isinstance(value, dict) else None
+
+
+def _opt_str(value: Any) -> str | None:
+    """Return ``value`` only when it is a non-empty string, else ``None``.
+
+    Mirrors the upstream ``activity.foo ? { foo } : {}`` spread guards, which
+    drop empty strings as well as ``undefined`` (an empty string is falsy in
+    JS). Keeping the same shape avoids emitting blank continuation fields.
+    """
+    return value if isinstance(value, str) and value else None
+
+
+def extract_teams_continuation(activity: TeamsActivity) -> TeamsContinuation:
+    """Build a :class:`TeamsContinuation` from a raw activity.
+
+    ``conversation_id`` / ``service_url`` default to ``""`` (upstream ``?? ""``)
+    so the continuation always carries the two fields a reply needs; the rest
+    are populated only when present, applying the same channelData fallbacks
+    as upstream (``channel.id`` then ``teamsChannelId``; ``team.id`` then
+    ``teamsTeamId``; ``conversation.tenantId`` then ``tenant.id``).
+    """
+    channel_data = _record(activity.get("channelData")) or {}
+    conversation = _record(activity.get("conversation")) or {}
+    channel = _record(channel_data.get("channel")) or {}
+    team = _record(channel_data.get("team")) or {}
+    tenant = _record(channel_data.get("tenant")) or {}
+
+    channel_id = _opt_str(channel.get("id"))
+    if channel_id is None:
+        channel_id = _opt_str(channel_data.get("teamsChannelId"))
+
+    team_id = _opt_str(team.get("id"))
+    if team_id is None:
+        team_id = _opt_str(channel_data.get("teamsTeamId"))
+
+    tenant_id = _opt_str(conversation.get("tenantId"))
+    if tenant_id is None:
+        tenant_id = _opt_str(tenant.get("id"))
+
+    conversation_id = conversation.get("id")
+    service_url = activity.get("serviceUrl")
+
+    return TeamsContinuation(
+        activity_id=_opt_str(activity.get("id")),
+        channel_id=channel_id,
+        conversation_id=conversation_id if isinstance(conversation_id, str) else "",
+        reply_to_id=_opt_str(activity.get("replyToId")),
+        service_url=service_url if isinstance(service_url, str) else "",
+        team_id=team_id,
+        tenant_id=tenant_id,
+    )
+
+
+def extract_teams_user(activity: TeamsActivity) -> TeamsWebhookUser | None:
+    """Return the acting user, or ``None`` when ``from.id`` is missing.
+
+    Upstream short-circuits on ``!activity.from?.id`` — a present user object
+    with no ``id`` yields ``None``. ``aadObjectId`` / ``name`` are included
+    only when truthy on the wire.
+    """
+    sender = _record(activity.get("from"))
+    if sender is None:
+        return None
+    user_id = sender.get("id")
+    if not (isinstance(user_id, str) and user_id):
+        return None
+    return TeamsWebhookUser(
+        aad_object_id=_opt_str(sender.get("aadObjectId")),
+        id=user_id,
+        name=_opt_str(sender.get("name")),
+    )
+
+
+def extract_teams_attachments(activity: TeamsActivity) -> list[TeamsWebhookAttachment]:
+    """Normalize ``activity.attachments``, skipping non-object entries.
+
+    Non-list ``attachments`` yields ``[]``; ``None`` / non-dict entries are
+    dropped. The typed ``content`` is the entry's ``content`` value (``None``
+    when absent); the key-present-vs-absent distinction (upstream's
+    ``typeof attachment.content === "undefined" ? {} : { content }``) is
+    preserved on ``raw``. ``content_type`` / ``content_url`` / ``name`` are
+    copied only when they are strings.
+    """
+    raw_attachments = activity.get("attachments")
+    if not isinstance(raw_attachments, list):
+        return []
+    result: list[TeamsWebhookAttachment] = []
+    for attachment in raw_attachments:
+        record = _record(attachment)
+        if record is None:
+            continue
+        content_type = record.get("contentType")
+        content_url = record.get("contentUrl")
+        name = record.get("name")
+        result.append(
+            TeamsWebhookAttachment(
+                # The typed ``content`` is ``None`` for both a missing key and an
+                # explicit ``null`` (upstream copies the value only when present,
+                # but the absent-value is itself ``undefined``/``None``). The
+                # key-present-vs-absent distinction is preserved in ``raw``.
+                content=record.get("content"),
+                content_type=content_type if isinstance(content_type, str) else None,
+                content_url=content_url if isinstance(content_url, str) else None,
+                name=name if isinstance(name, str) else None,
+                raw=record,
+            )
+        )
+    return result
+
+
+def is_teams_mention(activity: TeamsActivity, bot_app_id: str | None = None) -> bool:
+    """Return ``True`` when the activity @-mentions the bot.
+
+    Without a ``bot_app_id`` this is always ``False``. A match requires a
+    ``mention`` entity whose ``mentioned.id`` either equals ``bot_app_id`` or
+    ends with the exact ``":" + bot_app_id`` suffix (Bot Framework prefixes
+    user ids like ``28:<app-id>``).
+    """
+    if not bot_app_id:
+        return False
+    entities = activity.get("entities")
+    if not isinstance(entities, list):
+        return False
+    suffix = f":{bot_app_id}"
+    for entity in entities:
+        record = _record(entity)
+        if record is None or record.get("type") != "mention":
+            continue
+        mentioned = _record(record.get("mentioned"))
+        if mentioned is None:
+            continue
+        mentioned_id = mentioned.get("id")
+        if not isinstance(mentioned_id, str):
+            continue
+        if mentioned_id == bot_app_id or mentioned_id.endswith(suffix):
+            return True
+    return False

--- a/src/chat_sdk/adapters/teams/webhook/parse.py
+++ b/src/chat_sdk/adapters/teams/webhook/parse.py
@@ -1,0 +1,159 @@
+"""Parsing for the Teams webhook primitives subpath.
+
+Port of ``packages/adapter-teams/src/webhook/parse.ts`` (chat@4.31, commit
+8c71411). Classifies an inbound Bot Framework activity into a typed,
+discriminated payload (``message`` / ``card_action`` / ``dialog_open`` /
+``dialog_submit`` / ``message_reaction`` / ``conversation_update`` /
+``installation_update`` / ``unsupported``) without the full Teams adapter or
+the ``microsoft_teams`` SDK.
+
+Parse-ONLY: no JWT verification, no outbound HTTP. (JWT verification and the
+authenticated reply client live in sibling primitive subpaths.)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from chat_sdk.adapters.teams.webhook.continuation import (
+    extract_teams_attachments,
+    extract_teams_continuation,
+    extract_teams_user,
+    is_teams_mention,
+)
+from chat_sdk.adapters.teams.webhook.types import (
+    TeamsActivity,
+    TeamsCardActionPayload,
+    TeamsConversationUpdatePayload,
+    TeamsDialogOpenPayload,
+    TeamsDialogSubmitPayload,
+    TeamsInstallationUpdatePayload,
+    TeamsMessagePayload,
+    TeamsMessageReactionPayload,
+    TeamsParseOptions,
+    TeamsUnsupportedPayload,
+    TeamsWebhookParseError,
+    TeamsWebhookPayload,
+)
+
+
+def parse_teams_webhook_body(
+    body: str | Any,
+    options: TeamsParseOptions | None = None,
+) -> TeamsWebhookPayload:
+    """Classify a Teams webhook body into a typed payload.
+
+    ``body`` may be a JSON string (parsed here) or an already-decoded mapping.
+    A string that is not valid JSON, or a body that does not decode to an
+    object, raises :class:`TeamsWebhookParseError`.
+    """
+    if options is None:
+        options = TeamsParseOptions()
+    activity = _parse_activity(body)
+    continuation = extract_teams_continuation(activity)
+    user = extract_teams_user(activity)
+
+    activity_type = activity.get("type")
+
+    if activity_type == "message":
+        if _is_action_submit_message(activity):
+            return TeamsCardActionPayload(
+                action_id=_read_action_id(activity.get("value")),
+                continuation=continuation,
+                raw=activity,
+                user=user,
+                value=activity.get("value"),
+            )
+        text = activity.get("text")
+        return TeamsMessagePayload(
+            attachments=extract_teams_attachments(activity),
+            continuation=continuation,
+            is_mention=is_teams_mention(activity, options.bot_app_id),
+            raw=activity,
+            text=text if isinstance(text, str) else "",
+            user=user,
+        )
+
+    if activity_type == "messageReaction":
+        action = activity.get("action")
+        reply_to_id = activity.get("replyToId")
+        message_id = reply_to_id if reply_to_id is not None else activity.get("id")
+        return TeamsMessageReactionPayload(
+            action=action if isinstance(action, str) else None,
+            continuation=continuation,
+            message_id=message_id if isinstance(message_id, str) else None,
+            raw=activity,
+            user=user,
+        )
+
+    if activity_type == "invoke":
+        name = activity.get("name")
+        if name == "task/fetch":
+            return TeamsDialogOpenPayload(
+                continuation=continuation,
+                raw=activity,
+                user=user,
+                value=activity.get("value"),
+            )
+        if name == "task/submit":
+            return TeamsDialogSubmitPayload(
+                continuation=continuation,
+                raw=activity,
+                user=user,
+                value=activity.get("value"),
+            )
+        if name == "adaptiveCard/action":
+            return TeamsCardActionPayload(
+                action_id=_read_action_id(activity.get("value")),
+                continuation=continuation,
+                raw=activity,
+                user=user,
+                value=activity.get("value"),
+            )
+
+    if activity_type == "conversationUpdate":
+        return TeamsConversationUpdatePayload(continuation=continuation, raw=activity)
+
+    if activity_type == "installationUpdate":
+        action = activity.get("action")
+        return TeamsInstallationUpdatePayload(
+            action=action if isinstance(action, str) else None,
+            continuation=continuation,
+            raw=activity,
+        )
+
+    reason_type = activity_type if isinstance(activity_type, str) else "unknown"
+    return TeamsUnsupportedPayload(
+        continuation=continuation,
+        raw=activity,
+        reason=f"Unsupported Teams activity type: {reason_type}",
+    )
+
+
+def _parse_activity(body: str | Any) -> TeamsActivity:
+    if isinstance(body, str):
+        try:
+            parsed = json.loads(body)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise TeamsWebhookParseError("Invalid Teams webhook JSON body") from exc
+        return _assert_activity(parsed)
+    return _assert_activity(body)
+
+
+def _assert_activity(value: Any) -> TeamsActivity:
+    if not isinstance(value, dict):
+        raise TeamsWebhookParseError("Teams webhook body must be an object")
+    return value
+
+
+def _is_action_submit_message(activity: TeamsActivity) -> bool:
+    value = activity.get("value")
+    return isinstance(value, dict) and ("actionId" in value or "msteams" in value)
+
+
+def _read_action_id(value: Any) -> str | None:
+    if not (isinstance(value, dict) and "actionId" in value):
+        return None
+    action_id = value.get("actionId")
+    return action_id if isinstance(action_id, str) else None

--- a/src/chat_sdk/adapters/teams/webhook/types.py
+++ b/src/chat_sdk/adapters/teams/webhook/types.py
@@ -1,0 +1,174 @@
+"""Types for the Teams webhook primitives subpath.
+
+Port of ``packages/adapter-teams/src/webhook/types.ts`` (chat@4.31, commit
+8c71411). These types describe the lightweight, runtime-free webhook surface:
+classifying an inbound Bot Framework :class:`TeamsActivity` into typed,
+discriminated payload dataclasses with provider-native continuation data —
+without the full Teams adapter, the ``microsoft_teams`` SDK, chat state,
+dedupe, locks, or subscriptions.
+
+Wire-shape note (port rule: camelCase at the serialization boundary):
+the *typed* results use ``snake_case`` discriminated dataclasses, while the
+``raw`` passthrough preserves the original camelCase Bot Framework activity
+verbatim (``channelData.teamsChannelId``, ``replyToId``, ``aadObjectId``,
+``tenantId``, ...). Callers that need wire-exact fields read them from
+``raw``; callers that want a normalized view read the typed fields.
+
+Importing this module never imports ``microsoft_teams``, HTTP clients, or the
+high-level :mod:`chat_sdk.adapters.teams.adapter`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, TypeAlias
+
+# A raw Bot Framework activity, kept as a plain dict so the primitives stay
+# SDK-free. Upstream models this as ``TeamsActivity extends Record<string,
+# unknown>`` — every wire key (camelCase) survives untouched in this mapping.
+TeamsActivity: TypeAlias = dict[str, Any]
+
+
+@dataclass
+class TeamsContinuation:
+    """Provider-native continuation data for replying to an activity.
+
+    ``conversation_id`` and ``service_url`` are always present (empty string
+    when absent on the wire, mirroring upstream's ``?? ""``); every other
+    field is omitted entirely when the source value is missing.
+    """
+
+    conversation_id: str
+    service_url: str
+    activity_id: str | None = None
+    channel_id: str | None = None
+    reply_to_id: str | None = None
+    team_id: str | None = None
+    tenant_id: str | None = None
+
+
+@dataclass
+class TeamsWebhookUser:
+    """The acting Teams user extracted from ``activity.from``."""
+
+    id: str
+    aad_object_id: str | None = None
+    name: str | None = None
+
+
+@dataclass
+class TeamsWebhookAttachment:
+    """A normalized attachment, with the original entry kept in ``raw``."""
+
+    raw: dict[str, Any]
+    content: Any | None = None
+    content_type: str | None = None
+    content_url: str | None = None
+    name: str | None = None
+
+
+@dataclass
+class TeamsParseOptions:
+    """Options for :func:`parse_teams_webhook_body`."""
+
+    bot_app_id: str | None = None
+
+
+@dataclass
+class _TeamsPayloadBase:
+    """Shared fields for every classified Teams payload."""
+
+    raw: TeamsActivity
+    continuation: TeamsContinuation | None = None
+
+
+@dataclass
+class TeamsMessagePayload(_TeamsPayloadBase):
+    """A plain inbound ``message`` activity."""
+
+    attachments: list[TeamsWebhookAttachment] = field(default_factory=list)
+    is_mention: bool = False
+    text: str = ""
+    user: TeamsWebhookUser | None = None
+    kind: Literal["message"] = "message"
+
+
+@dataclass
+class TeamsMessageReactionPayload(_TeamsPayloadBase):
+    """A ``messageReaction`` activity (reaction add/remove)."""
+
+    action: str | None = None
+    message_id: str | None = None
+    user: TeamsWebhookUser | None = None
+    kind: Literal["message_reaction"] = "message_reaction"
+
+
+@dataclass
+class TeamsCardActionPayload(_TeamsPayloadBase):
+    """An Adaptive Card / ``Action.Submit`` action."""
+
+    action_id: str | None = None
+    user: TeamsWebhookUser | None = None
+    value: Any | None = None
+    kind: Literal["card_action"] = "card_action"
+
+
+@dataclass
+class TeamsDialogOpenPayload(_TeamsPayloadBase):
+    """A ``task/fetch`` invoke (dialog open request)."""
+
+    user: TeamsWebhookUser | None = None
+    value: Any | None = None
+    kind: Literal["dialog_open"] = "dialog_open"
+
+
+@dataclass
+class TeamsDialogSubmitPayload(_TeamsPayloadBase):
+    """A ``task/submit`` invoke (dialog submission)."""
+
+    user: TeamsWebhookUser | None = None
+    value: Any | None = None
+    kind: Literal["dialog_submit"] = "dialog_submit"
+
+
+@dataclass
+class TeamsConversationUpdatePayload(_TeamsPayloadBase):
+    """A ``conversationUpdate`` lifecycle activity."""
+
+    kind: Literal["conversation_update"] = "conversation_update"
+
+
+@dataclass
+class TeamsInstallationUpdatePayload(_TeamsPayloadBase):
+    """An ``installationUpdate`` lifecycle activity."""
+
+    action: str | None = None
+    kind: Literal["installation_update"] = "installation_update"
+
+
+@dataclass
+class TeamsUnsupportedPayload(_TeamsPayloadBase):
+    """Any activity the primitives recognize but do not model."""
+
+    reason: str = ""
+    kind: Literal["unsupported"] = "unsupported"
+
+
+TeamsWebhookPayload: TypeAlias = (
+    TeamsCardActionPayload
+    | TeamsConversationUpdatePayload
+    | TeamsDialogOpenPayload
+    | TeamsDialogSubmitPayload
+    | TeamsInstallationUpdatePayload
+    | TeamsMessagePayload
+    | TeamsMessageReactionPayload
+    | TeamsUnsupportedPayload
+)
+
+
+class TeamsWebhookError(Exception):
+    """Base error for the Teams webhook primitives."""
+
+
+class TeamsWebhookParseError(TeamsWebhookError):
+    """Raised when a Teams webhook body cannot be parsed."""

--- a/tests/test_teams_webhook_primitive.py
+++ b/tests/test_teams_webhook_primitive.py
@@ -242,24 +242,26 @@ class TestContinuationFallbacks:
         assert continuation.team_id is None
         assert continuation.tenant_id is None
 
-    def test_continuation_prefers_primary_over_fallback(self):
-        # ``channel.id`` wins over ``teamsChannelId``; ``team.id`` over
-        # ``teamsTeamId``; ``conversation.tenantId`` over ``tenant.id``.
+    def test_continuation_channeldata_wins_over_conversation(self):
+        # Upstream builds the continuation via an object spread where the later
+        # source wins: ``teamsChannelId`` beats ``channel.id``; ``teamsTeamId``
+        # beats ``team.id``; ``channelData.tenant.id`` beats
+        # ``conversation.tenantId``.
         continuation = extract_teams_continuation(
             {
                 "channelData": {
-                    "channel": {"id": "primary-channel"},
-                    "team": {"id": "primary-team"},
-                    "teamsChannelId": "fallback-channel",
-                    "teamsTeamId": "fallback-team",
-                    "tenant": {"id": "fallback-tenant"},
+                    "channel": {"id": "channel-id"},
+                    "team": {"id": "team-id"},
+                    "teamsChannelId": "teams-channel-id",
+                    "teamsTeamId": "teams-team-id",
+                    "tenant": {"id": "channeldata-tenant"},
                 },
-                "conversation": {"id": "c", "tenantId": "primary-tenant"},
+                "conversation": {"id": "c", "tenantId": "conversation-tenant"},
             }
         )
-        assert continuation.channel_id == "primary-channel"
-        assert continuation.team_id == "primary-team"
-        assert continuation.tenant_id == "primary-tenant"
+        assert continuation.channel_id == "teams-channel-id"
+        assert continuation.team_id == "teams-team-id"
+        assert continuation.tenant_id == "channeldata-tenant"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_teams_webhook_primitive.py
+++ b/tests/test_teams_webhook_primitive.py
@@ -1,0 +1,508 @@
+"""Tests for the Teams webhook primitives subpath.
+
+Port of ``packages/adapter-teams/src/webhook/index.test.ts`` and
+``webhook/boundary.test.ts`` (chat@4.31, commit 8c71411).
+
+Covers the 12 ``it`` cases from ``index.test.ts`` plus the 1 ``it`` source
+boundary case (13 upstream cases total), and adds adversarial/divergence
+cases that exercise the camelCase ``raw`` passthrough, the ``is not None``
+fallbacks, and explicit-``null`` content handling.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chat_sdk.adapters.teams.webhook import (
+    TeamsCardActionPayload,
+    TeamsContinuation,
+    TeamsConversationUpdatePayload,
+    TeamsDialogOpenPayload,
+    TeamsDialogSubmitPayload,
+    TeamsInstallationUpdatePayload,
+    TeamsMessagePayload,
+    TeamsMessageReactionPayload,
+    TeamsParseOptions,
+    TeamsUnsupportedPayload,
+    TeamsWebhookParseError,
+    TeamsWebhookUser,
+    extract_teams_attachments,
+    extract_teams_continuation,
+    extract_teams_user,
+    is_teams_mention,
+    parse_teams_webhook_body,
+    read_teams_webhook,
+)
+
+BASE_ACTIVITY: dict[str, Any] = {
+    "channelData": {
+        "channel": {"id": "channel-id"},
+        "team": {"id": "team-id"},
+        "tenant": {"id": "tenant-id"},
+    },
+    "conversation": {"id": "conversation-id"},
+    "from": {"aadObjectId": "aad-id", "id": "user-id", "name": "Ada"},
+    "id": "activity-id",
+    "serviceUrl": "https://smba.example/",
+}
+
+
+def _activity(**overrides: Any) -> dict[str, Any]:
+    return {**BASE_ACTIVITY, **overrides}
+
+
+class _FakeRequest:
+    """Duck-typed request exposing an async ``text()`` (Fetch-style)."""
+
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    async def text(self) -> str:
+        return self._body
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "parses message activities with continuation and mention state"
+# ---------------------------------------------------------------------------
+class TestParseMessage:
+    def test_parses_message_with_continuation_and_mention_state(self):
+        payload = parse_teams_webhook_body(
+            _activity(
+                entities=[
+                    {
+                        "mentioned": {"id": "28:bot-id", "name": "Bot"},
+                        "text": "<at>Bot</at>",
+                        "type": "mention",
+                    }
+                ],
+                text="<at>Bot</at> hello",
+                type="message",
+            ),
+            TeamsParseOptions(bot_app_id="bot-id"),
+        )
+
+        assert isinstance(payload, TeamsMessagePayload)
+        assert payload.kind == "message"
+        assert payload.is_mention is True
+        assert payload.text == "<at>Bot</at> hello"
+        assert payload.user == TeamsWebhookUser(aad_object_id="aad-id", id="user-id", name="Ada")
+        assert payload.continuation == TeamsContinuation(
+            activity_id="activity-id",
+            channel_id="channel-id",
+            conversation_id="conversation-id",
+            reply_to_id=None,
+            service_url="https://smba.example/",
+            team_id="team-id",
+            tenant_id="tenant-id",
+        )
+
+    def test_message_text_defaults_to_empty_string_when_absent(self):
+        # Divergence guard: upstream ``activity.text ?? ""`` — a missing/non-str
+        # text becomes "" rather than ``None``.
+        payload = parse_teams_webhook_body(_activity(type="message"))
+        assert isinstance(payload, TeamsMessagePayload)
+        assert payload.text == ""
+        assert payload.is_mention is False  # no bot_app_id given
+
+    def test_message_keeps_camelcase_wire_keys_in_raw_passthrough(self):
+        # Hazard: typed result is snake_case, but ``raw`` preserves camelCase.
+        activity = _activity(
+            channelData={"teamsChannelId": "tc", "teamsTeamId": "tt"},
+            replyToId="reply-99",
+            type="message",
+            text="hi",
+        )
+        payload = parse_teams_webhook_body(activity)
+        assert isinstance(payload, TeamsMessagePayload)
+        assert payload.raw is activity
+        assert payload.raw["channelData"]["teamsChannelId"] == "tc"
+        assert payload.raw["replyToId"] == "reply-99"
+        assert payload.raw["from"]["aadObjectId"] == "aad-id"
+        # ... while the typed continuation resolves the fallbacks to snake_case.
+        assert payload.continuation is not None
+        assert payload.continuation.channel_id == "tc"
+        assert payload.continuation.team_id == "tt"
+        assert payload.continuation.reply_to_id == "reply-99"
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "classifies card actions and dialogs"
+# ---------------------------------------------------------------------------
+class TestCardActionsAndDialogs:
+    def test_adaptive_card_action_invoke(self):
+        payload = parse_teams_webhook_body(
+            _activity(name="adaptiveCard/action", type="invoke", value={"actionId": "approve"})
+        )
+        assert isinstance(payload, TeamsCardActionPayload)
+        assert payload.kind == "card_action"
+        assert payload.action_id == "approve"
+        assert payload.value == {"actionId": "approve"}
+
+    def test_task_fetch_is_dialog_open(self):
+        payload = parse_teams_webhook_body(_activity(name="task/fetch", type="invoke"))
+        assert isinstance(payload, TeamsDialogOpenPayload)
+        assert payload.kind == "dialog_open"
+
+    def test_task_submit_is_dialog_submit(self):
+        payload = parse_teams_webhook_body(_activity(name="task/submit", type="invoke"))
+        assert isinstance(payload, TeamsDialogSubmitPayload)
+        assert payload.kind == "dialog_submit"
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "classifies reaction and lifecycle activities"
+# ---------------------------------------------------------------------------
+class TestReactionAndLifecycle:
+    def test_message_reaction(self):
+        payload = parse_teams_webhook_body(_activity(action="add", replyToId="message-id", type="messageReaction"))
+        assert isinstance(payload, TeamsMessageReactionPayload)
+        assert payload.kind == "message_reaction"
+        assert payload.action == "add"
+        assert payload.message_id == "message-id"
+
+    def test_message_reaction_falls_back_to_activity_id(self):
+        # Divergence guard: ``replyToId ?? id`` — without replyToId, the id is used.
+        payload = parse_teams_webhook_body(_activity(action="remove", type="messageReaction"))
+        assert isinstance(payload, TeamsMessageReactionPayload)
+        assert payload.message_id == "activity-id"
+        assert payload.action == "remove"
+
+    def test_conversation_update(self):
+        payload = parse_teams_webhook_body(_activity(type="conversationUpdate"))
+        assert isinstance(payload, TeamsConversationUpdatePayload)
+        assert payload.kind == "conversation_update"
+
+    def test_installation_update(self):
+        payload = parse_teams_webhook_body(_activity(action="add", type="installationUpdate"))
+        assert isinstance(payload, TeamsInstallationUpdatePayload)
+        assert payload.kind == "installation_update"
+        assert payload.action == "add"
+
+    def test_installation_update_non_string_action_is_none(self):
+        # ``typeof action === "string" ? action : undefined``
+        payload = parse_teams_webhook_body(_activity(action=123, type="installationUpdate"))
+        assert isinstance(payload, TeamsInstallationUpdatePayload)
+        assert payload.action is None
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "reads request bodies without verifying JWTs"
+# ---------------------------------------------------------------------------
+class TestReadTeamsWebhook:
+    @pytest.mark.asyncio
+    async def test_reads_request_body_without_verifying_jwts(self):
+        request = _FakeRequest(json.dumps(_activity(text="hello", type="message")))
+        payload = await read_teams_webhook(request)
+        assert payload.kind == "message"
+
+    @pytest.mark.asyncio
+    async def test_read_teams_webhook_threads_options(self):
+        # The options (bot_app_id) must reach the parser through the reader.
+        body = json.dumps(
+            _activity(
+                entities=[{"mentioned": {"id": "28:bot-id"}, "type": "mention"}],
+                text="hi",
+                type="message",
+            )
+        )
+        payload = await read_teams_webhook(_FakeRequest(body), TeamsParseOptions(bot_app_id="bot-id"))
+        assert isinstance(payload, TeamsMessagePayload)
+        assert payload.is_mention is True
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "extracts continuation from channelData fallbacks"
+# ---------------------------------------------------------------------------
+class TestContinuationFallbacks:
+    def test_extracts_continuation_from_channeldata_fallbacks(self):
+        continuation = extract_teams_continuation(
+            {
+                "channelData": {"teamsChannelId": "teams-channel", "teamsTeamId": "teams-team"},
+                "conversation": {"id": "conversation", "tenantId": "tenant"},
+                "serviceUrl": "service",
+            }
+        )
+        assert continuation.channel_id == "teams-channel"
+        assert continuation.conversation_id == "conversation"
+        assert continuation.service_url == "service"
+        assert continuation.team_id == "teams-team"
+        assert continuation.tenant_id == "tenant"
+
+    def test_continuation_defaults_when_fields_absent(self):
+        # Divergence guard: ``conversation_id``/``service_url`` default to "".
+        continuation = extract_teams_continuation({})
+        assert continuation.conversation_id == ""
+        assert continuation.service_url == ""
+        assert continuation.activity_id is None
+        assert continuation.channel_id is None
+        assert continuation.team_id is None
+        assert continuation.tenant_id is None
+
+    def test_continuation_prefers_primary_over_fallback(self):
+        # ``channel.id`` wins over ``teamsChannelId``; ``team.id`` over
+        # ``teamsTeamId``; ``conversation.tenantId`` over ``tenant.id``.
+        continuation = extract_teams_continuation(
+            {
+                "channelData": {
+                    "channel": {"id": "primary-channel"},
+                    "team": {"id": "primary-team"},
+                    "teamsChannelId": "fallback-channel",
+                    "teamsTeamId": "fallback-team",
+                    "tenant": {"id": "fallback-tenant"},
+                },
+                "conversation": {"id": "c", "tenantId": "primary-tenant"},
+            }
+        )
+        assert continuation.channel_id == "primary-channel"
+        assert continuation.team_id == "primary-team"
+        assert continuation.tenant_id == "primary-tenant"
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "throws parse errors for invalid JSON"
+# ---------------------------------------------------------------------------
+class TestParseErrors:
+    def test_throws_parse_error_for_invalid_json(self):
+        with pytest.raises(TeamsWebhookParseError):
+            parse_teams_webhook_body("{")
+
+    def test_invalid_json_message_matches_upstream(self):
+        with pytest.raises(TeamsWebhookParseError, match="Invalid Teams webhook JSON body"):
+            parse_teams_webhook_body("{")
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "rejects non-object JSON and non-string bodies"
+# ---------------------------------------------------------------------------
+class TestNonObjectBodies:
+    def test_rejects_non_object_json_string(self):
+        with pytest.raises(TeamsWebhookParseError):
+            parse_teams_webhook_body("null")
+
+    def test_rejects_non_string_body(self):
+        with pytest.raises(TeamsWebhookParseError):
+            parse_teams_webhook_body(42)
+
+    def test_non_object_body_message_matches_upstream(self):
+        with pytest.raises(TeamsWebhookParseError, match="Teams webhook body must be an object"):
+            parse_teams_webhook_body(42)
+
+    def test_accepts_already_decoded_mapping(self):
+        # A non-string mapping body is accepted directly (no JSON parse).
+        payload = parse_teams_webhook_body(_activity(type="conversationUpdate"))
+        assert payload.kind == "conversation_update"
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "classifies Action.Submit messages and msteams payloads as card actions"
+# ---------------------------------------------------------------------------
+class TestActionSubmitMessages:
+    def test_message_with_action_id_value_is_card_action(self):
+        payload = parse_teams_webhook_body(_activity(type="message", value={"actionId": "approve"}))
+        assert isinstance(payload, TeamsCardActionPayload)
+        assert payload.kind == "card_action"
+        assert payload.action_id == "approve"
+
+    def test_message_with_msteams_value_is_card_action_without_action_id(self):
+        payload = parse_teams_webhook_body(_activity(type="message", value={"msteams": {"type": "messageBack"}}))
+        assert isinstance(payload, TeamsCardActionPayload)
+        assert payload.kind == "card_action"
+        assert payload.action_id is None
+
+    def test_message_with_unrelated_value_stays_a_message(self):
+        # Divergence guard: a ``value`` without actionId/msteams keys is NOT a
+        # card action — it remains a plain message.
+        payload = parse_teams_webhook_body(_activity(type="message", text="hi", value={"foo": 1}))
+        assert isinstance(payload, TeamsMessagePayload)
+        assert payload.kind == "message"
+
+    def test_card_action_non_string_action_id_is_none(self):
+        # ``readActionId``: non-string actionId yields ``None``.
+        payload = parse_teams_webhook_body(_activity(type="message", value={"actionId": 7}))
+        assert isinstance(payload, TeamsCardActionPayload)
+        assert payload.action_id is None
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "marks unknown and unhandled activity types as unsupported"
+# ---------------------------------------------------------------------------
+class TestUnsupported:
+    def test_unknown_type_is_unsupported_with_reason(self):
+        payload = parse_teams_webhook_body(_activity(type="typing"))
+        assert isinstance(payload, TeamsUnsupportedPayload)
+        assert payload.kind == "unsupported"
+        assert payload.reason == "Unsupported Teams activity type: typing"
+
+    def test_unhandled_invoke_name_is_unsupported(self):
+        payload = parse_teams_webhook_body(_activity(name="signin/verifyState", type="invoke"))
+        assert isinstance(payload, TeamsUnsupportedPayload)
+        assert payload.kind == "unsupported"
+
+    def test_missing_type_reports_unknown(self):
+        payload = parse_teams_webhook_body(_activity())
+        assert isinstance(payload, TeamsUnsupportedPayload)
+        assert payload.reason == "Unsupported Teams activity type: unknown"
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "extracts a user only when an id is present"
+# ---------------------------------------------------------------------------
+class TestExtractUser:
+    def test_user_without_id_is_none(self):
+        assert extract_teams_user({"from": {"name": "Ada"}}) is None
+
+    def test_user_with_id_only(self):
+        assert extract_teams_user({"from": {"id": "user-id"}}) == TeamsWebhookUser(id="user-id")
+
+    def test_missing_from_is_none(self):
+        assert extract_teams_user({}) is None
+
+    def test_empty_string_id_is_none(self):
+        # ``!activity.from?.id`` — an empty-string id is falsy → None.
+        assert extract_teams_user({"from": {"id": ""}}) is None
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "normalizes attachments and skips non-object entries"
+# ---------------------------------------------------------------------------
+class TestExtractAttachments:
+    def test_normalizes_and_skips_non_object_entries(self):
+        attachments = extract_teams_attachments(
+            {
+                "attachments": [
+                    None,
+                    "bad",
+                    {
+                        "content": {"foo": 1},
+                        "contentType": "application/json",
+                        "contentUrl": "https://example.com/file",
+                        "name": "file",
+                    },
+                ]
+            }
+        )
+        assert len(attachments) == 1
+        only = attachments[0]
+        assert only.content == {"foo": 1}
+        assert only.content_type == "application/json"
+        assert only.content_url == "https://example.com/file"
+        assert only.name == "file"
+        assert only.raw == {
+            "content": {"foo": 1},
+            "contentType": "application/json",
+            "contentUrl": "https://example.com/file",
+            "name": "file",
+        }
+
+    def test_non_list_attachments_yields_empty(self):
+        assert extract_teams_attachments({}) == []
+        assert extract_teams_attachments({"attachments": "nope"}) == []
+
+    def test_explicit_null_content_is_preserved(self):
+        # Divergence guard: ``typeof content === "undefined" ? {} : { content }``
+        # — an explicit ``null`` content survives, a missing key stays None.
+        [with_null] = extract_teams_attachments({"attachments": [{"content": None}]})
+        assert with_null.content is None
+        assert "content" in with_null.raw
+        [without] = extract_teams_attachments({"attachments": [{"name": "x"}]})
+        assert without.content is None
+        assert "content" not in without.raw
+
+    def test_non_string_content_type_url_name_dropped(self):
+        [attachment] = extract_teams_attachments(
+            {"attachments": [{"contentType": 1, "contentUrl": 2, "name": 3, "content": "keep"}]}
+        )
+        assert attachment.content == "keep"
+        assert attachment.content_type is None
+        assert attachment.content_url is None
+        assert attachment.name is None
+
+
+# ---------------------------------------------------------------------------
+# Upstream: "detects mentions by id suffix and ignores them without a botAppId"
+# ---------------------------------------------------------------------------
+class TestIsTeamsMention:
+    def test_detects_mention_by_id_suffix(self):
+        activity = {"entities": [{"mentioned": {"id": "28:bot-id"}, "type": "mention"}]}
+        assert is_teams_mention(activity, "bot-id") is True
+
+    def test_ignores_without_bot_app_id(self):
+        activity = {"entities": [{"mentioned": {"id": "28:bot-id"}, "type": "mention"}]}
+        assert is_teams_mention(activity) is False
+
+    def test_exact_id_match(self):
+        activity = {"entities": [{"mentioned": {"id": "bot-id"}, "type": "mention"}]}
+        assert is_teams_mention(activity, "bot-id") is True
+
+    def test_partial_suffix_without_colon_does_not_match(self):
+        # Adversarial: ``endsWith(":" + botAppId)`` requires the exact ":" join.
+        # "29-bot-id" ends with "bot-id" but NOT with ":bot-id".
+        activity = {"entities": [{"mentioned": {"id": "29-bot-id"}, "type": "mention"}]}
+        assert is_teams_mention(activity, "bot-id") is False
+
+    def test_non_mention_entity_ignored(self):
+        activity = {"entities": [{"mentioned": {"id": "28:bot-id"}, "type": "clientInfo"}]}
+        assert is_teams_mention(activity, "bot-id") is False
+
+    def test_non_list_entities_is_false(self):
+        assert is_teams_mention({"entities": "nope"}, "bot-id") is False
+        assert is_teams_mention({}, "bot-id") is False
+
+
+# ---------------------------------------------------------------------------
+# Upstream boundary.test.ts: "does not import the full adapter or runtime packages"
+# ---------------------------------------------------------------------------
+class TestWebhookImportBoundary:
+    def test_source_does_not_import_sdk_or_adapter(self):
+        """Source-scan boundary (faithful port of upstream's
+        ``webhook/boundary.test.ts``): the webhook subpackage's own ``.py``
+        files must not import the ``microsoft_teams`` SDK, an HTTP client, the
+        shared runtime, or the high-level Teams adapter.
+
+        DIVERGENCE FROM SLACK: a runtime ``sys.modules`` boundary check is not
+        usable yet because the Teams package ``__init__`` still eagerly imports
+        the adapter (the PEP-562 lazy conversion lands in packaging PR T7).
+        Upstream's boundary test is itself a source scan, so this mirrors it.
+        """
+        directory = Path(__file__).resolve().parents[1] / "src" / "chat_sdk" / "adapters" / "teams" / "webhook"
+        sources = [path for path in directory.glob("*.py")]
+        assert sources, f"no webhook source files found under {directory}"
+        # Scan only the *import lines* (stripped) so prose docstrings that name
+        # ``microsoft_teams`` as a thing-we-don't-import are not false positives
+        # — mirroring upstream's intent (it scans for ``from "@microsoft/..."``).
+        import_lines = [
+            line.strip()
+            for path in sources
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip().startswith(("import ", "from "))
+        ]
+        combined_imports = "\n".join(import_lines)
+
+        forbidden = [
+            "microsoft_teams",
+            "import httpx",
+            "import aiohttp",
+            "import requests",
+            "from chat_sdk.adapters.teams.adapter",
+            "import chat_sdk.adapters.teams.adapter",
+            "from chat_sdk.adapters.teams.cards",
+            "from chat_sdk.adapters.teams.bridge",
+        ]
+        hits = [token for token in forbidden if token in combined_imports]
+        assert not hits, f"webhook subpath source imports forbidden modules: {hits}"
+
+    def test_subpackage_imports_only_within_itself(self):
+        # Every ``chat_sdk`` import in the subpackage stays inside the webhook
+        # subpath (no reach into sibling Teams modules).
+        directory = Path(__file__).resolve().parents[1] / "src" / "chat_sdk" / "adapters" / "teams" / "webhook"
+        for path in directory.glob("*.py"):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if stripped.startswith(("from chat_sdk", "import chat_sdk")):
+                    assert "chat_sdk.adapters.teams.webhook" in stripped, (
+                        f"{path.name}: non-webhook chat_sdk import: {stripped}"
+                    )


### PR DESCRIPTION
## Summary

Ports the NET-NEW Teams **webhook** primitives subpackage from `packages/adapter-teams/src/webhook` (chat@4.31.0, commit `8c71411`), mirroring the existing `slack/webhook/` layout. These primitives are **SDK-free** (plain dicts + stdlib only, no `microsoft_teams.*` imports) and are **parse-only** — no JWT verification, no outbound HTTP.

New subpackage `src/chat_sdk/adapters/teams/webhook/`:
- `types.py` — discriminated `snake_case` payload dataclasses + `TeamsWebhookParseError`
- `continuation.py` — `extract_teams_continuation` / `extract_teams_user` / `extract_teams_attachments` / `is_teams_mention`
- `parse.py` — `parse_teams_webhook_body` (activity classifier)
- `__init__.py` — package surface + `read_teams_webhook` / `read_teams_request_body`

## Classification

`parse_teams_webhook_body` classifies an inbound Bot Framework activity into:
`message` / `card_action` (Action.Submit + `adaptiveCard/action`) / `dialog_open` (`task/fetch`) / `dialog_submit` (`task/submit`) / `message_reaction` / `conversation_update` / `installation_update` / `unsupported`.

## Hazards handled (port rules)

- **camelCase at the wire boundary**: typed results are `snake_case` dataclasses; the raw Bot Framework activity (`channelData.teamsChannelId`, `replyToId`, `aadObjectId`, `tenantId`, ...) is preserved verbatim on each payload's `raw` passthrough.
- **Truthiness trap**: `is not None` / membership checks throughout (`replyToId ?? id`, channelData fallbacks), never `or`.
- **Parse errors**: invalid JSON and non-object bodies raise `TeamsWebhookParseError`.
- **Mention matching**: `is_teams_mention` requires the exact `":" + bot_app_id` suffix (or exact id), matching upstream.

## Strict lane scoping

Only the new `webhook/` subpackage and its test file are added. The Teams package `__init__.py` is **untouched** — PEP-562 lazy subpath registration is deferred to the packaging PR (T7). No shared files (`adapter.py`, `cards.py`, `types.py`, `CHANGELOG.md`) modified.

## Tests

`tests/test_teams_webhook_primitive.py` — 45 cases porting the 12 `index.test.ts` `it` cases + the 1 source-boundary case (13 upstream total), with adversarial/divergence coverage: camelCase `raw` passthrough, `replyToId ?? id` fallback, primary-over-fallback continuation precedence, mention `:`-suffix edge cases, and explicit-`null` content handling.

The boundary test is a **source-scan** (faithful to upstream's `boundary.test.ts`, which scans `.ts` source for forbidden imports) rather than a runtime `sys.modules` check — the latter is not usable until the Teams package `__init__` is made lazy in T7. Mutation-verified: it fails when a forbidden import is injected.

## Gauntlet

- `ruff check`: PASS
- `ruff format --check`: PASS
- `audit_test_quality.py`: PASS (0 hard failures)
- `pyrefly check`: 0 errors
- `pytest tests/`: 4922 passed, 4 skipped