### PR TITLE
feat(teams): cards primitive — input helpers (chat@4.31 8c71411)

### DIFF
--- a/src/chat_sdk/adapters/teams/cards_input.py
+++ b/src/chat_sdk/adapters/teams/cards_input.py
@@ -1,0 +1,205 @@
+"""Generic input-request Adaptive Card helpers for the Teams cards primitive.
+
+Port of ``packages/adapter-teams/src/cards-primitives/input.ts`` (NEW in
+chat@4.31.0, commit ``8c71411``), the net-new input surface that ships
+alongside the cards primitive (``cards-primitives/index.ts`` is already
+covered SDK-free by :mod:`chat_sdk.adapters.teams.cards`).
+
+Builds Adaptive Card JSON for prompt/option input requests (buttons, radio,
+select, and freeform text) and parses the corresponding ``Action.Submit``
+payloads back into structured responses. Input shapes are TypedDicts with
+snake_case keys (``request_id``, ``allow_freeform``, ``option_id``,
+``action_id``) — upstream uses camelCase. The emitted Adaptive Card dicts and
+the inbound ``data`` keys keep Teams' on-the-wire camelCase field names
+(``actionId``, ``isMultiSelect``, ``isMultiline`` …) so the bytes match
+upstream exactly.
+
+Importing this module never imports the ``microsoft_teams`` SDK, an HTTP
+client, or the high-level :mod:`chat_sdk.adapters.teams.adapter` module. Like
+upstream's ``input.ts``, the input helpers perform no escaping (they emit raw
+prompt / label / option strings into ``TextBlock`` / ``Input.ChoiceSet``
+fields); the :mod:`chat_sdk.adapters.teams.format` primitive is the place to
+reach for when a caller needs escaping, but the faithful port does not apply it
+here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, NotRequired, TypedDict
+
+__all__ = [
+    "TEAMS_FREEFORM_ACTION_ID",
+    "TEAMS_INPUT_ACTION_PREFIX",
+    "TeamsInputAction",
+    "TeamsInputOption",
+    "TeamsInputRequest",
+    "TeamsInputResponse",
+    "input_request_to_teams_adaptive_card",
+    "parse_teams_input_response",
+]
+
+# Upstream constants (cards-primitives/input.ts). The option ChoiceSet id and
+# every Action.Submit ``actionId`` are prefixed with this; the freeform
+# Input.Text element uses the fixed freeform id below. Both are exact — the
+# adapter's action router matches on them verbatim.
+TEAMS_INPUT_ACTION_PREFIX = "input:"
+TEAMS_FREEFORM_ACTION_ID = "input-freeform"
+
+_ADAPTIVE_CARD_SCHEMA = "http://adaptivecards.io/schemas/adaptive-card.json"
+_ADAPTIVE_CARD_VERSION = "1.4"
+
+
+class TeamsInputOption(TypedDict):
+    """One selectable option in an input request."""
+
+    id: str
+    label: str
+    description: NotRequired[str]
+    style: NotRequired[Literal["danger", "default", "primary"]]
+
+
+class TeamsInputRequest(TypedDict):
+    """A prompt with optional options rendered as an Adaptive Card."""
+
+    prompt: str
+    request_id: str
+    allow_freeform: NotRequired[bool]
+    display: NotRequired[Literal["buttons", "radio", "select"]]
+    options: NotRequired[list[TeamsInputOption]]
+
+
+class TeamsInputAction(TypedDict):
+    """An inbound ``Action.Submit`` payload to parse into a response."""
+
+    action_id: NotRequired[str]
+    value: NotRequired[Any]
+
+
+class TeamsInputResponse(TypedDict):
+    """The parsed result of an input interaction."""
+
+    request_id: str
+    option_id: NotRequired[str]
+    value: NotRequired[str]
+
+
+def input_request_to_teams_adaptive_card(request: TeamsInputRequest) -> dict[str, Any]:
+    """Render an input request as a Teams Adaptive Card dict.
+
+    Port of ``inputRequestToTeamsAdaptiveCard``. ``select`` / ``radio`` render
+    a single ``Input.ChoiceSet`` plus one ``Submit`` action; otherwise each
+    option becomes its own ``Action.Submit`` button. ``allow_freeform`` adds an
+    ``Input.Text`` element and a dedicated "Submit answer" action.
+    """
+    request_id = request["request_id"]
+    input_action_id = f"{TEAMS_INPUT_ACTION_PREFIX}{request_id}"
+    body: list[dict[str, Any]] = [
+        {
+            "text": request["prompt"],
+            "type": "TextBlock",
+            "wrap": True,
+        }
+    ]
+    actions: list[dict[str, Any]] = []
+    options = request.get("options") or []
+
+    display = request.get("display")
+    if display in ("select", "radio"):
+        body.append(
+            {
+                "choices": [{"title": option["label"], "value": option["id"]} for option in options],
+                "id": input_action_id,
+                "isMultiSelect": False,
+                "style": "expanded" if display == "radio" else "compact",
+                "type": "Input.ChoiceSet",
+            }
+        )
+        actions.append(
+            {
+                "data": {"actionId": input_action_id},
+                "title": "Submit",
+                "type": "Action.Submit",
+            }
+        )
+    else:
+        for option in options:
+            actions.append(
+                {
+                    "data": {
+                        "actionId": input_action_id,
+                        "value": option["id"],
+                    },
+                    "title": option["label"],
+                    "type": "Action.Submit",
+                }
+            )
+
+    if request.get("allow_freeform"):
+        body.append(
+            {
+                "id": TEAMS_FREEFORM_ACTION_ID,
+                "isMultiline": True,
+                "placeholder": "Type your answer",
+                "type": "Input.Text",
+            }
+        )
+        actions.append(
+            {
+                "data": {
+                    "actionId": input_action_id,
+                    "freeform": True,
+                },
+                "title": "Submit answer",
+                "type": "Action.Submit",
+            }
+        )
+
+    return {
+        "$schema": _ADAPTIVE_CARD_SCHEMA,
+        "actions": actions,
+        "body": body,
+        "type": "AdaptiveCard",
+        "version": _ADAPTIVE_CARD_VERSION,
+    }
+
+
+def parse_teams_input_response(action: TeamsInputAction) -> TeamsInputResponse | None:
+    """Parse an inbound ``Action.Submit`` payload, or ``None``.
+
+    Port of ``parseTeamsInputResponse``. Returns ``None`` unless ``action_id``
+    starts with :data:`TEAMS_INPUT_ACTION_PREFIX`. A top-level string ``value``
+    is treated as the chosen ``option_id`` (button submit); otherwise the
+    option id is read from the request-scoped ChoiceSet key and the freeform
+    answer from the freeform key. Only string-typed, non-empty values pass —
+    matching upstream's ``typeof === "string"`` reads and truthiness guards.
+    """
+    action_id = action.get("action_id")
+    if action_id is None or not action_id.startswith(TEAMS_INPUT_ACTION_PREFIX):
+        return None
+
+    request_id = action_id[len(TEAMS_INPUT_ACTION_PREFIX) :]
+    input_action_id = f"{TEAMS_INPUT_ACTION_PREFIX}{request_id}"
+    value = action.get("value")
+
+    if isinstance(value, str):
+        option_id: str | None = value
+        freeform_value: str | None = None
+    else:
+        option_id = _read_string_value(value, input_action_id)
+        freeform_value = _read_string_value(value, TEAMS_FREEFORM_ACTION_ID)
+
+    response: TeamsInputResponse = {"request_id": request_id}
+    if option_id:
+        response["option_id"] = option_id
+        response["value"] = option_id
+    if freeform_value:
+        response["value"] = freeform_value
+    return response
+
+
+def _read_string_value(value: Any, key: str) -> str | None:
+    """Read ``value[key]`` only when it is a string in a dict-like ``value``."""
+    if not (isinstance(value, dict) and key in value):
+        return None
+    field = value[key]
+    return field if isinstance(field, str) else None

--- a/tests/test_teams_cards_primitive.py
+++ b/tests/test_teams_cards_primitive.py
@@ -1,0 +1,282 @@
+"""Tests for the Teams cards-primitive input helpers (chat@4.31, 8c71411).
+
+Ports the input-specific ``it`` blocks from upstream
+``packages/adapter-teams/src/cards-primitives/index.test.ts`` plus the
+``boundary.test.ts`` import-isolation check. The card-emit ``it`` blocks
+(``cardToAdaptiveCard`` / ``cardToTeamsFallbackText``) are already exercised
+by ``tests/test_teams_cards.py`` against :mod:`chat_sdk.adapters.teams.cards`,
+so they are not re-ported here to avoid cross-file duplication.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chat_sdk.adapters.teams.cards_input import (
+    TEAMS_FREEFORM_ACTION_ID,
+    TEAMS_INPUT_ACTION_PREFIX,
+    input_request_to_teams_adaptive_card,
+    parse_teams_input_response,
+)
+
+
+class TestInputRequestRoundTrip:
+    """Build + parse input request cards (port of upstream input ``it`` blocks)."""
+
+    def test_builds_and_parses_input_request_cards(self) -> None:
+        """it("builds and parses input request cards")."""
+        card = input_request_to_teams_adaptive_card(
+            {
+                "options": [{"id": "approve", "label": "Approve"}],
+                "prompt": "Approve?",
+                "request_id": "deploy",
+            }
+        )
+
+        assert card["actions"] == [
+            {
+                "data": {"actionId": "input:deploy", "value": "approve"},
+                "title": "Approve",
+                "type": "Action.Submit",
+            }
+        ]
+        assert parse_teams_input_response({"action_id": "input:deploy", "value": "approve"}) == {
+            "option_id": "approve",
+            "request_id": "deploy",
+            "value": "approve",
+        }
+
+    def test_parses_radio_input_values_submitted_under_action_id(self) -> None:
+        """it.each(["radio"])("parses %s input values submitted under the action id")."""
+        card = input_request_to_teams_adaptive_card(
+            {
+                "display": "radio",
+                "options": [{"id": "approve", "label": "Approve"}],
+                "prompt": "Approve?",
+                "request_id": "deploy",
+            }
+        )
+
+        choice_sets = [element for element in card["body"] if element.get("type") == "Input.ChoiceSet"]
+        assert choice_sets == [
+            {
+                "choices": [{"title": "Approve", "value": "approve"}],
+                "id": "input:deploy",
+                "isMultiSelect": False,
+                "style": "expanded",
+                "type": "Input.ChoiceSet",
+            }
+        ]
+        assert parse_teams_input_response({"action_id": "input:deploy", "value": {"input:deploy": "approve"}}) == {
+            "option_id": "approve",
+            "request_id": "deploy",
+            "value": "approve",
+        }
+
+    def test_parses_select_input_values_submitted_under_action_id(self) -> None:
+        """it.each(["select"])("parses %s input values submitted under the action id")."""
+        card = input_request_to_teams_adaptive_card(
+            {
+                "display": "select",
+                "options": [{"id": "approve", "label": "Approve"}],
+                "prompt": "Approve?",
+                "request_id": "deploy",
+            }
+        )
+
+        choice_sets = [element for element in card["body"] if element.get("type") == "Input.ChoiceSet"]
+        assert choice_sets == [
+            {
+                "choices": [{"title": "Approve", "value": "approve"}],
+                "id": "input:deploy",
+                "isMultiSelect": False,
+                "style": "compact",
+                "type": "Input.ChoiceSet",
+            }
+        ]
+        # The single submit action carries only the request-scoped actionId.
+        assert card["actions"] == [
+            {
+                "data": {"actionId": "input:deploy"},
+                "title": "Submit",
+                "type": "Action.Submit",
+            }
+        ]
+        assert parse_teams_input_response({"action_id": "input:deploy", "value": {"input:deploy": "approve"}}) == {
+            "option_id": "approve",
+            "request_id": "deploy",
+            "value": "approve",
+        }
+
+    def test_parses_freeform_text_submitted_under_freeform_input_id(self) -> None:
+        """it("parses freeform text submitted under the freeform input id")."""
+        card = input_request_to_teams_adaptive_card(
+            {
+                "allow_freeform": True,
+                "options": [{"id": "approve", "label": "Approve"}],
+                "prompt": "Approve or explain?",
+                "request_id": "deploy",
+            }
+        )
+
+        text_inputs = [element for element in card["body"] if element.get("type") == "Input.Text"]
+        assert text_inputs == [
+            {
+                "id": "input-freeform",
+                "isMultiline": True,
+                "placeholder": "Type your answer",
+                "type": "Input.Text",
+            }
+        ]
+        # A dedicated freeform submit action plus the per-option button.
+        assert {
+            "data": {"actionId": "input:deploy", "freeform": True},
+            "title": "Submit answer",
+            "type": "Action.Submit",
+        } in card["actions"]
+        assert parse_teams_input_response(
+            {
+                "action_id": "input:deploy",
+                "value": {"input-freeform": "Needs more testing"},
+            }
+        ) == {"request_id": "deploy", "value": "Needs more testing"}
+
+    def test_returns_parse_failures_for_unknown_action_ids(self) -> None:
+        """it("returns parse failures for unknown action ids")."""
+        assert parse_teams_input_response({"action_id": "other:deploy"}) is None
+        assert parse_teams_input_response({}) is None
+
+
+class TestParseEdgeCases:
+    """Adversarial parse cases beyond the upstream happy paths."""
+
+    def test_freeform_overrides_option_id_when_both_present(self) -> None:
+        # Upstream spread order: optionId sets {optionId, value}, then a
+        # truthy freeformValue overwrites value. optionId is retained.
+        result = parse_teams_input_response(
+            {
+                "action_id": "input:deploy",
+                "value": {
+                    "input:deploy": "approve",
+                    "input-freeform": "but check logs",
+                },
+            }
+        )
+        assert result == {
+            "option_id": "approve",
+            "request_id": "deploy",
+            "value": "but check logs",
+        }
+
+    def test_empty_request_id_still_parses(self) -> None:
+        # The prefix alone yields an empty request_id; upstream keeps it.
+        assert parse_teams_input_response({"action_id": "input:"}) == {"request_id": ""}
+
+    def test_non_string_choice_value_is_ignored(self) -> None:
+        # A numeric ChoiceSet value is not a string → no option_id/value.
+        assert parse_teams_input_response({"action_id": "input:deploy", "value": {"input:deploy": 42}}) == {
+            "request_id": "deploy"
+        }
+
+    def test_empty_string_value_does_not_set_option_id(self) -> None:
+        # Falsy (empty) string fails the truthiness guard → no option_id.
+        assert parse_teams_input_response({"action_id": "input:deploy", "value": ""}) == {"request_id": "deploy"}
+
+    def test_missing_value_yields_request_id_only(self) -> None:
+        assert parse_teams_input_response({"action_id": "input:deploy"}) == {"request_id": "deploy"}
+
+    def test_dict_value_without_matching_keys_yields_request_id_only(self) -> None:
+        assert parse_teams_input_response({"action_id": "input:deploy", "value": {"unrelated": "x"}}) == {
+            "request_id": "deploy"
+        }
+
+    def test_buttons_display_emits_one_submit_per_option(self) -> None:
+        card = input_request_to_teams_adaptive_card(
+            {
+                "display": "buttons",
+                "options": [
+                    {"id": "a", "label": "A"},
+                    {"id": "b", "label": "B"},
+                ],
+                "prompt": "Pick",
+                "request_id": "r1",
+            }
+        )
+        assert card["actions"] == [
+            {
+                "data": {"actionId": "input:r1", "value": "a"},
+                "title": "A",
+                "type": "Action.Submit",
+            },
+            {
+                "data": {"actionId": "input:r1", "value": "b"},
+                "title": "B",
+                "type": "Action.Submit",
+            },
+        ]
+        # No ChoiceSet / Text input in the body for the buttons display.
+        assert all(element.get("type") == "TextBlock" for element in card["body"])
+
+    def test_card_envelope_constants_and_schema(self) -> None:
+        card = input_request_to_teams_adaptive_card({"prompt": "Hi", "request_id": "x"})
+        assert card["$schema"] == "http://adaptivecards.io/schemas/adaptive-card.json"
+        assert card["type"] == "AdaptiveCard"
+        assert card["version"] == "1.4"
+        # Empty options + no freeform → only the prompt TextBlock, no actions.
+        assert card["body"] == [{"text": "Hi", "type": "TextBlock", "wrap": True}]
+        assert card["actions"] == []
+
+    def test_exact_constant_values(self) -> None:
+        # Unforgeable sentinels: the wire prefix / freeform id must be exact.
+        assert TEAMS_INPUT_ACTION_PREFIX == "input:"
+        assert TEAMS_FREEFORM_ACTION_ID == "input-freeform"
+
+
+class TestCardsPrimitiveBoundary:
+    """Port of cards-primitives/boundary.test.ts — import isolation."""
+
+    def test_input_module_does_not_import_sdk_or_runtime(self) -> None:
+        """it("does not import the full adapter or runtime packages")."""
+        path = Path(__file__).resolve().parents[1] / "src" / "chat_sdk" / "adapters" / "teams" / "cards_input.py"
+        # Only consider import-statement lines so a docstring mention of
+        # ``microsoft_teams`` is not a false positive (mirrors the Round-1
+        # webhook/api boundary source scans).
+        imports = "\n".join(
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.lstrip().startswith(("import ", "from "))
+        )
+
+        assert "microsoft_teams" not in imports
+        assert "chat_sdk.adapters.teams.adapter" not in imports
+        assert "httpx" not in imports
+
+    def test_importing_input_module_does_not_load_sdk_or_http_client(self) -> None:
+        """Importing the input helpers in a fresh interpreter must not load the
+        ``microsoft_teams`` SDK or any HTTP client.
+
+        Run in a *subprocess* so the shared test process's ``sys.modules`` is
+        never mutated (a global mutation here would pollute downstream
+        module-identity assertions). Mirrors the Round-1 api/webhook boundary
+        tests: we do NOT assert the high-level adapter is absent, because the
+        eager ``teams/__init__.py`` pulls it in transitively until the lazy
+        subpath registration lands in packaging PR T7 — the source scan above
+        already proves the input module itself never imports the adapter.
+        """
+        import subprocess
+        import sys
+
+        code = (
+            "import importlib, sys\n"
+            "importlib.import_module('chat_sdk.adapters.teams.cards_input')\n"
+            "forbidden = ['microsoft_teams', 'httpx', 'aiohttp']\n"
+            "loaded = [n for n in forbidden if n in sys.modules]\n"
+            "assert not loaded, f'input module eagerly imported: {loaded}'\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Ports the **net-new** Teams cards-primitive **input** surface from upstream chat@4.31.0 (commit `8c71411`):
`packages/adapter-teams/src/cards-primitives/input.ts`.

`cards-primitives/index.ts` (`cardToAdaptiveCard` / `cardToTeamsFallbackText`) is already covered SDK-free by `adapters/teams/cards.py`, so per the recommended approach this PR **keeps `cards.py` and ADDS the net-new input helpers** in a sibling module (`adapters/teams/cards_input.py`), mirroring the Slack `blocks/input.py` template.

### New surface (`src/chat_sdk/adapters/teams/cards_input.py`)
- `input_request_to_teams_adaptive_card(request)` — builds the Adaptive Card (buttons / radio / select / freeform).
- `parse_teams_input_response(action)` — parses the inbound `Action.Submit` payload, or `None`.
- Constants `TEAMS_INPUT_ACTION_PREFIX = "input:"`, `TEAMS_FREEFORM_ACTION_ID = "input-freeform"`.
- TypedDicts `TeamsInputOption` / `TeamsInputRequest` / `TeamsInputAction` / `TeamsInputResponse`.

### Port fidelity / hazards
- **SDK-free**: plain dicts, no `microsoft_teams` import; no eager HTTP client.
- **Emit symmetry**: input shapes are snake_case; on-the-wire keys stay camelCase (`actionId`, `isMultiSelect`, `isMultiline`, `freeform`). The `__auto_submit` actionId is unchanged (lives in `cards.py`); the input-action prefix is exact.
- **Parse truthiness**: top-level string `value` → `option_id`; otherwise reads the request-scoped ChoiceSet key and the freeform key, accepting only string-typed values (`isinstance` guard) and non-empty strings (truthiness guard) — matching upstream's `typeof === "string"` reads and spread order (freeform overrides `value` when both present, `option_id` retained).
- **No escaping** in the input helpers (faithful to upstream `input.ts`, which imports nothing from `format`).

### Tests (`tests/test_teams_cards_primitive.py`)
Ports the input-specific `it()` blocks from `cards-primitives/index.test.ts` (the card-emit `it()` blocks stay in `test_teams_cards.py` to avoid cross-file duplication), plus the `boundary.test.ts` import-isolation check and adversarial parse cases (non-string / empty-string / both-keys / dict-without-keys / empty-request-id).

## Lane scoping
No forbidden files touched — `teams/__init__.py` (lazy subpath deferred to T7), `adapter.py`, `cards.py`, other primitives, `CHANGELOG.md`, `docs/UPSTREAM_SYNC.md` are all unchanged. Divergence rows for this round are consolidated in T7.

## Gauntlet
- `ruff check` ✅ · `ruff format --check` ✅ · `audit_test_quality.py` ✅ (0 hard failures) · `pyrefly check` ✅ (0 errors) · `pytest` ✅ **4978 passed, 4 skipped**
- fidelity (pinned 4.29) ✅ 732/732