### PR TITLE
feat(teams): graph primitive subpath + SSRF allowlist divergence (chat@4.31 8c71411)

### DIFF
--- a/src/chat_sdk/adapters/teams/graph/__init__.py
+++ b/src/chat_sdk/adapters/teams/graph/__init__.py
@@ -1,0 +1,453 @@
+"""Microsoft Graph primitives for Teams — a runtime-free subpath.
+
+Port of ``packages/adapter-teams/src/graph/`` (``client.ts``, ``channels.ts``,
+``messages.ts``, ``types.ts``; NEW in chat@4.31.0, commit ``8c71411``), exposed
+upstream as ``@chat-adapter/teams/graph``. Provides fetch-based primitives for
+calling the Microsoft Graph REST API with a Graph-scoped Bot Framework token:
+acquiring the token at the ``https://graph.microsoft.com/.default`` scope,
+calling an arbitrary Graph endpoint, following ``@odata.nextLink`` pagination,
+reading a channel's metadata, listing chat / channel messages and replies,
+reading a single channel message, and extracting plain text from a Graph
+message's HTML body — independent of the full Teams adapter, the
+``microsoft_teams`` SDK, and the chat runtime.
+
+The token-acquisition, response-body reading, and error type are reused from the
+sibling ``chat_sdk.adapters.teams.api`` subpath (the cross-subpath import mirrors
+upstream's ``import { ... } from "../api/client"``). Importing this module never
+imports ``microsoft_teams`` or an HTTP client; the default ``fetch`` (inherited
+from the api subpath) lazily imports ``httpx`` only when a request is actually
+made, and any HTTP stack can be injected via the ``fetch`` parameter.
+
+The injectable ``fetch`` is an async callable::
+
+    async def fetch(url, *, method="GET", headers=None, body=None) -> response
+
+where ``response`` exposes an ``int`` ``status`` (or ``status_code``), an
+``ok`` flag (optional; derived from ``status`` when absent), and a ``text()``
+method (sync or async) returning the raw body string.
+
+Python-specific hardening (divergence from upstream, see ``docs/UPSTREAM_SYNC.md``
+Known Non-Parity): :func:`call_teams_graph_api` gates an absolute ``path_or_url``
+(and, transitively, each ``@odata.nextLink`` followed by :func:`paginate_teams_graph`)
+through :func:`is_trusted_graph_url` **before** attaching the ``Bearer`` token,
+refusing to forward the Graph token to any host outside ``graph.microsoft.com``
+(SSRF / token-leak guard). Upstream attaches the token to whatever URL it is
+handed — including an attacker-controlled ``@odata.nextLink`` — with no host
+check.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote, urljoin, urlparse
+
+from chat_sdk.adapters.teams.api import (
+    TeamsApiError,
+    TeamsCredentials,
+    TeamsFetch,
+    read_response_body,
+    resolve_teams_access_token,
+)
+from chat_sdk.adapters.teams.api import (
+    _default_fetch as _default_fetch,  # noqa: PLC2701 — reuse the api subpath's lazy-httpx transport
+)
+from chat_sdk.adapters.teams.api import (
+    _response_ok as _response_ok,  # noqa: PLC2701 — reuse the api subpath's response protocol helpers
+)
+from chat_sdk.adapters.teams.api import (
+    _response_status as _response_status,  # noqa: PLC2701
+)
+
+__all__ = [
+    "GetTeamsChannelMessageOptions",
+    "GetTeamsChannelOptions",
+    "ListTeamsChannelMessagesOptions",
+    "ListTeamsChatMessagesOptions",
+    "ListTeamsMessageRepliesOptions",
+    "TeamsChannelInfo",
+    "TeamsGraphListOptions",
+    "TeamsGraphListResult",
+    "TeamsGraphMessage",
+    "TeamsGraphOptions",
+    "TeamsGraphUser",
+    "call_teams_graph_api",
+    "extract_text_from_graph_message",
+    "get_teams_channel",
+    "get_teams_channel_message",
+    "is_trusted_graph_url",
+    "list_teams_channel_messages",
+    "list_teams_chat_messages",
+    "list_teams_message_replies",
+    "paginate_teams_graph",
+    "resolve_graph_access_token",
+    "to_graph_message",
+]
+
+_DEFAULT_GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+_DEFAULT_GRAPH_URL = "https://graph.microsoft.com/v1.0/"
+_LEADING_SLASH_PATTERN = re.compile(r"^/+")
+
+# SSRF allowlist (Python-first divergence from upstream). The Microsoft Graph
+# API lives on a single host; the Graph-scoped bearer token must never be
+# attached to any other host, including an attacker-supplied ``@odata.nextLink``.
+# This is the API-host counterpart to the broader file-download allowlist in the
+# high-level adapter (``teams/adapter.py`` ``_is_trusted_teams_download_url``,
+# which permits the ``.graph.microsoft.com`` suffix and the exact
+# ``graph.microsoft.com`` host); a Graph *API* call only ever targets the bare
+# ``graph.microsoft.com`` host, so we pin to it exactly.
+_TRUSTED_GRAPH_HOSTS = frozenset({"graph.microsoft.com"})
+
+
+@dataclass
+class TeamsGraphOptions:
+    """Options common to every Graph call.
+
+    ``credentials`` is reused from the api subpath; ``fetch`` injects an HTTP
+    transport (defaulting to lazy ``httpx``); ``graph_url`` overrides the base
+    Graph URL for relative paths (defaults to
+    ``https://graph.microsoft.com/v1.0/``).
+    """
+
+    credentials: TeamsCredentials
+    fetch: TeamsFetch | None = None
+    graph_url: str | None = None
+
+
+@dataclass
+class TeamsGraphListOptions(TeamsGraphOptions):
+    """:class:`TeamsGraphOptions` plus an optional ``$top`` page-size ``limit``."""
+
+    limit: int | None = None
+
+
+@dataclass
+class GetTeamsChannelOptions(TeamsGraphOptions):
+    """Options for :func:`get_teams_channel`."""
+
+    # Defaulted so the dataclass can extend the optional-field base; both are
+    # required in practice (``call_teams_graph_api`` encodes them into the path).
+    channel_id: str = ""
+    team_id: str = ""
+
+
+@dataclass
+class ListTeamsChatMessagesOptions(TeamsGraphListOptions):
+    """Options for :func:`list_teams_chat_messages`."""
+
+    chat_id: str = ""
+
+
+@dataclass
+class ListTeamsChannelMessagesOptions(TeamsGraphListOptions):
+    """Options for :func:`list_teams_channel_messages`."""
+
+    channel_id: str = ""
+    team_id: str = ""
+
+
+@dataclass
+class ListTeamsMessageRepliesOptions(TeamsGraphListOptions):
+    """Options for :func:`list_teams_message_replies`."""
+
+    channel_id: str = ""
+    message_id: str = ""
+    team_id: str = ""
+
+
+@dataclass
+class GetTeamsChannelMessageOptions(TeamsGraphOptions):
+    """Options for :func:`get_teams_channel_message`."""
+
+    channel_id: str = ""
+    message_id: str = ""
+    team_id: str = ""
+
+
+@dataclass
+class TeamsGraphUser:
+    """The ``from.user`` block of a Graph chat message."""
+
+    display_name: str | None = None
+    id: str | None = None
+    user_identity_type: str | None = None
+
+
+@dataclass
+class TeamsGraphMessage:
+    """A normalized Graph message (text extracted from the HTML body)."""
+
+    id: str
+    text: str
+    raw: dict[str, Any]
+    created_at: str | None = None
+    from_: TeamsGraphUser | None = None
+    reply_to_id: str | None = None
+
+
+@dataclass
+class TeamsGraphListResult:
+    """A page of :class:`TeamsGraphMessage` items plus an optional cursor.
+
+    ``cursor`` carries the raw ``@odata.nextLink`` (used as-is — never
+    re-encoded — for :func:`paginate_teams_graph`).
+    """
+
+    items: list[TeamsGraphMessage]
+    raw: dict[str, Any]
+    cursor: str | None = None
+
+
+@dataclass
+class TeamsChannelInfo:
+    """Channel metadata returned by :func:`get_teams_channel`."""
+
+    id: str
+    raw: dict[str, Any]
+    display_name: str | None = None
+
+
+def is_trusted_graph_url(url: str) -> bool:
+    """Return ``True`` when ``url`` targets the Microsoft Graph API host.
+
+    Python-first SSRF / token-leak guard (no upstream counterpart): only an
+    ``https://`` URL whose host is exactly ``graph.microsoft.com`` is trusted to
+    receive the Graph-scoped bearer token. Used to gate both an absolute
+    ``path_or_url`` and a followed ``@odata.nextLink`` **before** the token is
+    attached. Parse failures fail closed.
+    """
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return False
+    if parsed.scheme != "https":
+        return False
+    host = (parsed.hostname or "").lower()
+    return host in _TRUSTED_GRAPH_HOSTS
+
+
+async def resolve_graph_access_token(options: TeamsGraphOptions) -> str:
+    """Resolve a Bot Framework token scoped for Microsoft Graph.
+
+    Port of upstream ``resolveGraphAccessToken`` — delegates to the api subpath's
+    :func:`resolve_teams_access_token` with the fixed Graph scope
+    ``https://graph.microsoft.com/.default``.
+    """
+    return await resolve_teams_access_token(
+        options.credentials,
+        fetch=options.fetch,
+        scope=_DEFAULT_GRAPH_SCOPE,
+    )
+
+
+async def call_teams_graph_api(path_or_url: str, options: TeamsGraphOptions) -> Any:
+    """Call a Microsoft Graph endpoint with a Graph-scoped bearer token.
+
+    Port of upstream ``callTeamsGraphApi``. An absolute ``path_or_url`` (one
+    starting with ``http``) is used as-is; otherwise it is joined onto the base
+    Graph URL (``options.graph_url`` or ``https://graph.microsoft.com/v1.0/``)
+    after stripping leading slashes. Raises :class:`TeamsApiError` for non-2xx
+    responses.
+
+    Python-specific hardening: an absolute ``path_or_url`` is validated through
+    :func:`is_trusted_graph_url` **before** the token is resolved or attached,
+    raising :class:`ValueError` for any host other than ``graph.microsoft.com``.
+    This is what gates a hostile ``@odata.nextLink`` followed via
+    :func:`paginate_teams_graph`. Relative paths are always joined onto the
+    trusted base URL, so they need no host check. Upstream performs no such
+    check.
+    """
+    if path_or_url.startswith("http"):
+        if not is_trusted_graph_url(path_or_url):
+            raise ValueError(f"Refusing to call Microsoft Graph API on untrusted host: {path_or_url}")
+        url = path_or_url
+    else:
+        url = urljoin(
+            options.graph_url if options.graph_url is not None else _DEFAULT_GRAPH_URL,
+            _LEADING_SLASH_PATTERN.sub("", path_or_url),
+        )
+
+    request = options.fetch if options.fetch is not None else _default_fetch
+    token = await resolve_graph_access_token(options)
+
+    response = await request(
+        url,
+        method="GET",
+        headers={"authorization": f"Bearer {token}"},
+    )
+    body = await read_response_body(response)
+
+    if not _response_ok(response):
+        raise TeamsApiError(
+            "Microsoft Graph request failed",
+            body=body,
+            status=_response_status(response),
+        )
+
+    return body
+
+
+async def paginate_teams_graph(next_link: str, options: TeamsGraphOptions) -> Any:
+    """Follow an ``@odata.nextLink`` page URL.
+
+    Port of upstream ``paginateTeamsGraph``: the ``next_link`` is passed to
+    :func:`call_teams_graph_api` **as-is** (never re-encoded) — and is therefore
+    subject to the same host allowlist before the token attaches.
+    """
+    return await call_teams_graph_api(next_link, options)
+
+
+async def get_teams_channel(options: GetTeamsChannelOptions) -> TeamsChannelInfo:
+    """Read a channel's metadata via ``GET teams/{team}/channels/{channel}``.
+
+    Port of upstream ``getTeamsChannel``. ``id`` falls back to the requested
+    ``channel_id`` and ``display_name`` is omitted when Graph returns neither.
+    """
+    channel = await call_teams_graph_api(
+        f"teams/{quote(options.team_id, safe='')}/channels/{quote(options.channel_id, safe='')}",
+        options,
+    )
+    channel = channel if isinstance(channel, Mapping) else {}
+    display_name = channel.get("displayName")
+    channel_id = channel.get("id")
+    return TeamsChannelInfo(
+        id=channel_id if channel_id is not None else options.channel_id,
+        raw=dict(channel),
+        display_name=display_name if display_name else None,
+    )
+
+
+async def list_teams_chat_messages(
+    options: ListTeamsChatMessagesOptions,
+) -> TeamsGraphListResult:
+    """List messages in a 1:1 / group chat via ``GET chats/{chat}/messages``."""
+    result = await call_teams_graph_api(
+        _with_top(f"chats/{quote(options.chat_id, safe='')}/messages", options.limit),
+        options,
+    )
+    return _to_list_result(result)
+
+
+async def list_teams_channel_messages(
+    options: ListTeamsChannelMessagesOptions,
+) -> TeamsGraphListResult:
+    """List channel messages via ``GET teams/{team}/channels/{channel}/messages``."""
+    result = await call_teams_graph_api(
+        _with_top(
+            f"teams/{quote(options.team_id, safe='')}/channels/{quote(options.channel_id, safe='')}/messages",
+            options.limit,
+        ),
+        options,
+    )
+    return _to_list_result(result)
+
+
+async def list_teams_message_replies(
+    options: ListTeamsMessageRepliesOptions,
+) -> TeamsGraphListResult:
+    """List replies to a channel message via the ``/replies`` endpoint."""
+    result = await call_teams_graph_api(
+        _with_top(
+            f"teams/{quote(options.team_id, safe='')}/channels/{quote(options.channel_id, safe='')}"
+            f"/messages/{quote(options.message_id, safe='')}/replies",
+            options.limit,
+        ),
+        options,
+    )
+    return _to_list_result(result)
+
+
+async def get_teams_channel_message(
+    options: GetTeamsChannelMessageOptions,
+) -> TeamsGraphMessage:
+    """Read a single channel message via its ``messages/{message}`` endpoint."""
+    result = await call_teams_graph_api(
+        f"teams/{quote(options.team_id, safe='')}/channels/{quote(options.channel_id, safe='')}"
+        f"/messages/{quote(options.message_id, safe='')}",
+        options,
+    )
+    return to_graph_message(result if isinstance(result, Mapping) else {})
+
+
+def to_graph_message(message: Mapping[str, Any]) -> TeamsGraphMessage:
+    """Normalize a raw Graph chat message into a :class:`TeamsGraphMessage`.
+
+    Port of upstream ``toGraphMessage``: ``created_at``, ``from_`` and
+    ``reply_to_id`` are populated only when present; ``id`` defaults to ``""``;
+    ``text`` is extracted from the HTML body. ``raw`` is a shallow copy of the
+    input.
+    """
+    raw = dict(message)
+    message_id = message.get("id")
+    from_block = message.get("from")
+    user = from_block.get("user") if isinstance(from_block, Mapping) else None
+    created_at = message.get("createdDateTime")
+    reply_to_id = message.get("replyToId")
+    return TeamsGraphMessage(
+        id=message_id if message_id is not None else "",
+        text=extract_text_from_graph_message(message),
+        raw=raw,
+        created_at=created_at if created_at else None,
+        from_=_to_graph_user(user) if user else None,
+        reply_to_id=reply_to_id if reply_to_id else None,
+    )
+
+
+def extract_text_from_graph_message(message: Mapping[str, Any]) -> str:
+    """Convert a Graph message's HTML body to plain text.
+
+    Port of upstream ``extractTextFromGraphMessage``: a single ordered regex
+    pass — ``<at>`` mentions become ``@name``, ``<br>`` becomes a newline, a
+    ``</p><p>`` boundary becomes a blank line, remaining tags are stripped, then
+    the named entities are decoded. ``&amp;`` is decoded **last** so an encoded
+    ``&lt;`` in the source never becomes ``<`` then gets mistaken for a tag, and
+    a literal ``&amp;lt;`` decodes to ``&lt;`` rather than ``<``.
+    """
+    body = message.get("body")
+    content = body.get("content") if isinstance(body, Mapping) else None
+    if not content:
+        return ""
+    content = re.sub(r"<at\b[^>]*>(.*?)</at>", r"@\1", content, flags=re.IGNORECASE | re.DOTALL)
+    content = re.sub(r"<br\s*/?>", "\n", content, flags=re.IGNORECASE)
+    content = re.sub(r"</p>\s*<p[^>]*>", "\n\n", content, flags=re.IGNORECASE)
+    content = re.sub(r"<[^>]+>", "", content)
+    content = content.replace("&nbsp;", " ")
+    content = content.replace("&lt;", "<")
+    content = content.replace("&gt;", ">")
+    content = content.replace("&amp;", "&")
+    return content.strip()
+
+
+def _to_graph_user(user: Mapping[str, Any]) -> TeamsGraphUser:
+    return TeamsGraphUser(
+        display_name=user.get("displayName"),
+        id=user.get("id"),
+        user_identity_type=user.get("userIdentityType"),
+    )
+
+
+def _to_list_result(result: Any) -> TeamsGraphListResult:
+    result = result if isinstance(result, Mapping) else {}
+    next_link = result.get("@odata.nextLink")
+    value = result.get("value")
+    items_source = value if isinstance(value, list) else []
+    return TeamsGraphListResult(
+        items=[to_graph_message(item if isinstance(item, Mapping) else {}) for item in items_source],
+        raw=dict(result),
+        cursor=next_link if next_link else None,
+    )
+
+
+def _with_top(path: str, limit: int | None) -> str:
+    """Append a ``$top`` query parameter when ``limit`` is truthy.
+
+    Mirrors upstream ``withTop``: ``limit`` of ``0`` / ``None`` is a no-op
+    (the truthiness here is intentional parity). The ``$top`` token is appended
+    raw — the base path is already percent-encoded.
+    """
+    if not limit:
+        return path
+    separator = "&" if "?" in path else "?"
+    return f"{path}{separator}$top={limit}"

--- a/tests/test_teams_graph_primitive.py
+++ b/tests/test_teams_graph_primitive.py
@@ -1,0 +1,407 @@
+"""Tests for the runtime-free Microsoft Graph primitives subpath for Teams.
+
+Port of ``packages/adapter-teams/src/graph/index.test.ts`` and
+``graph/boundary.test.ts`` (NEW in chat@4.31.0, commit ``8c71411``), exposed
+upstream as ``@chat-adapter/teams/graph``. These primitives never touch the
+network in tests: a fake ``fetch`` (an :class:`~unittest.mock.AsyncMock`) is
+injected and its recorded calls are asserted, mirroring upstream's ``vi.fn()``
+request mocks. The first injected call always resolves the Graph-scoped token
+(``access_token``); subsequent calls return the Graph response bodies.
+
+Python-specific divergence (no upstream counterpart, see
+``docs/UPSTREAM_SYNC.md`` Known Non-Parity): the Graph-scoped bearer token is
+attached only to the ``graph.microsoft.com`` host. A dedicated test asserts a
+hostile ``@odata.nextLink`` is rejected (``ValueError``) *before* the token is
+fetched — the SSRF / token-leak guard. Upstream follows whatever ``nextLink``
+the server returns with no host check.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from urllib.parse import parse_qs
+
+import pytest
+
+from chat_sdk.adapters.teams.api import TeamsApiError, TeamsCredentials
+from chat_sdk.adapters.teams.graph import (
+    TeamsChannelInfo,
+    TeamsGraphMessage,
+    extract_text_from_graph_message,
+    get_teams_channel,
+    get_teams_channel_message,
+    is_trusted_graph_url,
+    list_teams_channel_messages,
+    list_teams_chat_messages,
+    list_teams_message_replies,
+    paginate_teams_graph,
+    to_graph_message,
+)
+
+CREDENTIALS = TeamsCredentials(
+    app_id="app-id",
+    app_password="secret",
+    tenant_id="tenant-id",
+)
+
+# A Graph-scoped token-response body and a sentinel attacker host used by the
+# SSRF divergence test.
+_TOKEN_BODY = {"access_token": "graph-token"}
+_ATTACKER_NEXT_LINK = "https://evil.example.com/v1.0/next"
+
+
+class _Response:
+    """Minimal stand-in for the injected fetch's response object.
+
+    Exposes ``status``, an ``ok`` flag, and a sync ``text()`` returning the raw
+    body string — the shape :func:`read_response_body` and the Graph client
+    read (mirroring the DOM ``Response`` upstream constructs).
+    """
+
+    def __init__(self, body: str, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status < 300
+
+    def text(self) -> str:
+        return self._body
+
+
+def _json_response(value: Any, status: int = 200) -> _Response:
+    return _Response(json.dumps(value), status)
+
+
+def _fetch(*responses: _Response) -> AsyncMock:
+    """Build an injectable async fetch returning ``responses`` in order."""
+    return AsyncMock(side_effect=list(responses))
+
+
+def _url(call_args: Any) -> str:
+    """Stringify the URL positional arg of a recorded fetch call."""
+    return str(call_args.args[0])
+
+
+def _headers(call_args: Any) -> dict[str, str]:
+    return call_args.kwargs["headers"]
+
+
+class TestTeamsGraphPrimitives:
+    """Port of upstream ``graph/index.test.ts`` (7 ``it`` blocks)."""
+
+    @pytest.mark.asyncio
+    async def test_lists_chat_messages_with_graph_token_scope(self) -> None:
+        request = _fetch(
+            _json_response(_TOKEN_BODY),
+            _json_response(
+                {
+                    "@odata.nextLink": "https://graph.microsoft.com/v1.0/next",
+                    "value": [
+                        {
+                            "body": {
+                                "content": "<p>Hello <b>world</b></p>",
+                                "contentType": "html",
+                            },
+                            "createdDateTime": "2026-01-01T00:00:00Z",
+                            "from": {"user": {"displayName": "Ada", "id": "user"}},
+                            "id": "message-id",
+                        }
+                    ],
+                }
+            ),
+        )
+
+        result = await list_teams_chat_messages(
+            _opts("chat", chat_id="19:chat", limit=5, fetch=request),
+        )
+
+        # The token request (call 0) carries the Graph ``.default`` scope.
+        token_body = parse_qs(request.await_args_list[0].kwargs["body"])
+        assert token_body["scope"] == ["https://graph.microsoft.com/.default"]
+        # The data request (call 1) is the encoded chat-messages URL with $top.
+        assert _url(request.await_args_list[1]) == ("https://graph.microsoft.com/v1.0/chats/19%3Achat/messages?$top=5")
+        # The resolved Graph token is attached as the Bearer credential.
+        assert _headers(request.await_args_list[1])["authorization"] == "Bearer graph-token"
+        assert request.await_args_list[1].kwargs["method"] == "GET"
+        assert result.cursor == "https://graph.microsoft.com/v1.0/next"
+        assert len(result.items) == 1
+        assert result.items[0].id == "message-id"
+        assert result.items[0].text == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_lists_channel_messages_and_replies(self) -> None:
+        request = _fetch(
+            _json_response(_TOKEN_BODY),
+            _json_response({"value": []}),
+            _json_response(_TOKEN_BODY),
+            _json_response({"value": []}),
+        )
+
+        await list_teams_channel_messages(
+            _opts("channel_messages", channel_id="channel", team_id="team", fetch=request),
+        )
+        await list_teams_message_replies(
+            _opts(
+                "replies",
+                channel_id="channel",
+                message_id="root",
+                team_id="team",
+                fetch=request,
+            ),
+        )
+
+        assert _url(request.await_args_list[1]) == (
+            "https://graph.microsoft.com/v1.0/teams/team/channels/channel/messages"
+        )
+        assert _url(request.await_args_list[3]) == (
+            "https://graph.microsoft.com/v1.0/teams/team/channels/channel/messages/root/replies"
+        )
+
+    @pytest.mark.asyncio
+    async def test_gets_a_channel_message_and_channel_info(self) -> None:
+        request = _fetch(
+            _json_response(_TOKEN_BODY),
+            _json_response({"body": {"content": "hello"}, "id": "m"}),
+            _json_response(_TOKEN_BODY),
+            _json_response({"displayName": "General", "id": "c"}),
+        )
+
+        message = await get_teams_channel_message(
+            _opts(
+                "message",
+                channel_id="c",
+                message_id="m",
+                team_id="t",
+                fetch=request,
+            ),
+        )
+        assert message.id == "m"
+        assert message.text == "hello"
+
+        channel = await get_teams_channel(
+            _opts("get_channel", channel_id="c", team_id="t", fetch=request),
+        )
+        assert channel.display_name == "General"
+        assert channel.id == "c"
+
+    @pytest.mark.asyncio
+    async def test_paginates_next_links(self) -> None:
+        request = _fetch(
+            _json_response(_TOKEN_BODY),
+            _json_response({"value": []}),
+        )
+
+        await paginate_teams_graph(
+            "https://graph.microsoft.com/v1.0/next",
+            _opts("paginate", fetch=request),
+        )
+
+        # The nextLink is used verbatim (not re-encoded) for the data call.
+        assert _url(request.await_args_list[1]) == "https://graph.microsoft.com/v1.0/next"
+
+    @pytest.mark.asyncio
+    async def test_throws_teams_api_error_when_graph_responds_with_an_error(self) -> None:
+        request = _fetch(
+            _json_response(_TOKEN_BODY),
+            _json_response({"error": "forbidden"}, status=403),
+        )
+
+        with pytest.raises(TeamsApiError) as excinfo:
+            await list_teams_chat_messages(_opts("chat", chat_id="c", fetch=request))
+        assert excinfo.value.status == 403
+
+    @pytest.mark.asyncio
+    async def test_returns_sparse_messages_with_empty_text_and_minimal_fields(self) -> None:
+        request = _fetch(
+            _json_response(_TOKEN_BODY),
+            _json_response({"value": [{"id": "m"}]}),
+        )
+
+        result = await list_teams_chat_messages(_opts("chat", chat_id="c", fetch=request))
+
+        # Exact equality: no created_at / from_ / reply_to_id populated.
+        assert result.items[0] == TeamsGraphMessage(id="m", raw={"id": "m"}, text="")
+        assert result.items[0].created_at is None
+        assert result.items[0].from_ is None
+        assert result.items[0].reply_to_id is None
+        assert result.cursor is None
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_channel_id_and_omits_display_name(self) -> None:
+        request = _fetch(
+            _json_response(_TOKEN_BODY),
+            _json_response({}),
+        )
+
+        channel = await get_teams_channel(
+            _opts("get_channel", channel_id="c-id", team_id="t", fetch=request),
+        )
+
+        assert channel == TeamsChannelInfo(id="c-id", raw={})
+        assert channel.display_name is None
+
+
+class TestTeamsGraphTextExtraction:
+    """Direct coverage of the ordered ``extractTextFromGraphMessage`` regex pass
+    and ``toGraphMessage`` shaping (the helpers exercised indirectly above)."""
+
+    def test_empty_body_yields_empty_text(self) -> None:
+        assert extract_text_from_graph_message({}) == ""
+        assert extract_text_from_graph_message({"body": {"content": ""}}) == ""
+
+    def test_converts_mentions_breaks_paragraphs_and_decodes_entities(self) -> None:
+        content = "<at>Ada</at> said:<br/>line<br>two</p><p>next &nbsp;&lt;tag&gt;&amp;done"
+        assert extract_text_from_graph_message({"body": {"content": content}}) == (
+            "@Ada said:\nline\ntwo\n\nnext  <tag>&done"
+        )
+
+    def test_decodes_amp_last_so_encoded_entities_survive(self) -> None:
+        # ``&amp;lt;`` must decode to ``&lt;`` (literal), NOT to ``<``: ``&amp;``
+        # is the LAST replacement, so the ``&lt;`` pass never sees this ``<``.
+        assert extract_text_from_graph_message({"body": {"content": "a &amp;lt; b"}}) == "a &lt; b"
+
+    def test_to_graph_message_populates_optional_fields_when_present(self) -> None:
+        message = to_graph_message(
+            {
+                "id": "m1",
+                "createdDateTime": "2026-01-01T00:00:00Z",
+                "from": {"user": {"displayName": "Ada", "id": "u", "userIdentityType": "aadUser"}},
+                "replyToId": "root",
+                "body": {"content": "hi"},
+            }
+        )
+        assert message.created_at == "2026-01-01T00:00:00Z"
+        assert message.reply_to_id == "root"
+        assert message.from_ is not None
+        assert message.from_.display_name == "Ada"
+        assert message.from_.user_identity_type == "aadUser"
+
+
+class TestTeamsGraphSsrfDivergence:
+    """Python-first SSRF / token-leak guard (no upstream counterpart)."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_an_attacker_next_link_host_before_attaching_the_token(self) -> None:
+        request = _fetch(_json_response(_TOKEN_BODY))
+
+        with pytest.raises(ValueError, match="untrusted host"):
+            await paginate_teams_graph(_ATTACKER_NEXT_LINK, _opts("paginate", fetch=request))
+
+        # Critically: the gate fires BEFORE any token is fetched — the injected
+        # fetch is never awaited, so the Graph token never leaves the process.
+        request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_call_with_an_absolute_attacker_url_is_rejected(self) -> None:
+        request = _fetch(_json_response(_TOKEN_BODY))
+
+        with pytest.raises(ValueError, match="untrusted host"):
+            # A list-helper limit path is relative; but a caller can pass an
+            # absolute hostile URL through ``paginate_teams_graph``. Assert the
+            # http(s)-prefixed branch is what's gated.
+            await paginate_teams_graph("http://graph.microsoft.com/v1.0/next", _opts("p", fetch=request))
+        request.assert_not_awaited()
+
+    def test_is_trusted_graph_url_allowlist(self) -> None:
+        assert is_trusted_graph_url("https://graph.microsoft.com/v1.0/next") is True
+        # Wrong scheme, lookalike suffix, foreign host, and parse junk all fail.
+        assert is_trusted_graph_url("http://graph.microsoft.com/v1.0/next") is False
+        assert is_trusted_graph_url("https://graph.microsoft.com.attacker.example/x") is False
+        assert is_trusted_graph_url("https://evil.example.com/x") is False
+        assert is_trusted_graph_url("://nonsense") is False
+
+
+class TestGraphImportBoundary:
+    """Port of upstream ``graph/boundary.test.ts``.
+
+    Upstream's boundary test is a **static source-scan**: it reads every
+    non-test ``.ts`` in the ``graph/`` directory and asserts the source never
+    imports the full adapter (``"chat"``), the shared runtime, or
+    ``@microsoft/teams.apps``. We port that source-scan over the ``graph/``
+    package's ``.py`` files. The cross-subpath import from
+    ``chat_sdk.adapters.teams.api`` is *expected* and allowed (it mirrors
+    upstream's ``import ... from "../api/client"``); only the high-level
+    adapter / SDK imports are forbidden.
+    """
+
+    def test_graph_source_does_not_import_the_adapter_sdk_or_runtime(self) -> None:
+        import chat_sdk.adapters.teams.graph as graph_pkg
+
+        package_dir = Path(graph_pkg.__file__).parent
+        sources = [
+            path.read_text(encoding="utf-8")
+            for path in sorted(package_dir.glob("*.py"))
+            if not path.name.startswith("test_")
+        ]
+        assert sources, "expected at least one graph source file"
+        joined = "\n".join(sources)
+
+        # No Teams SDK import in any form.
+        assert "import microsoft_teams" not in joined
+        assert "from microsoft_teams" not in joined
+        # No high-level adapter / shared-runtime imports (the api subpath is OK).
+        assert "from chat_sdk.adapters.teams.adapter" not in joined
+        assert "import chat_sdk.adapters.teams.adapter" not in joined
+        assert "from chat_sdk.adapters.teams.bridge" not in joined
+        assert "from chat_sdk.adapters.teams.cards" not in joined
+        # No eager HTTP-client import (httpx is lazily imported inside the
+        # default fetch only — inherited from the api subpath).
+        for source in sources:
+            assert "\nimport httpx" not in source, "httpx must be lazily imported"
+            assert "\nimport aiohttp" not in source
+
+    def test_importing_graph_does_not_eagerly_import_an_http_client(self) -> None:
+        """Importing the graph subpath in a fresh interpreter must not load an
+        HTTP client — the default fetch (from the api subpath) imports ``httpx``
+        lazily.
+        """
+        code = (
+            "import sys\n"
+            "import chat_sdk.adapters.teams.graph\n"
+            "forbidden = ['microsoft_teams', 'httpx', 'aiohttp']\n"
+            "loaded = [name for name in forbidden if name in sys.modules]\n"
+            "assert not loaded, f'graph subpath eagerly imported: {loaded}'\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+def _opts(kind: str, *, fetch: AsyncMock, **fields: Any) -> Any:
+    """Construct the right options dataclass for ``kind`` with ``CREDENTIALS``.
+
+    Keeps each test call terse while threading the shared credentials and the
+    injected fetch through the typed options objects. ``kind`` names the call
+    site exactly (no overloading), so each maps to one options class.
+    """
+    from chat_sdk.adapters.teams.graph import (
+        GetTeamsChannelMessageOptions,
+        GetTeamsChannelOptions,
+        ListTeamsChannelMessagesOptions,
+        ListTeamsChatMessagesOptions,
+        ListTeamsMessageRepliesOptions,
+        TeamsGraphOptions,
+    )
+
+    table = {
+        "chat": ListTeamsChatMessagesOptions,
+        "channel_messages": ListTeamsChannelMessagesOptions,
+        "replies": ListTeamsMessageRepliesOptions,
+        "message": GetTeamsChannelMessageOptions,
+        "get_channel": GetTeamsChannelOptions,
+        "paginate": TeamsGraphOptions,
+        "p": TeamsGraphOptions,
+    }
+    factory = table[kind]
+    return factory(credentials=CREDENTIALS, fetch=fetch, **fields)


### PR DESCRIPTION
## Summary

Ports the Microsoft **Graph** primitives subpath for Teams — NEW in chat@4.31.0 (`packages/adapter-teams/src/graph/`, commit `8c71411`), exposed upstream as `@chat-adapter/teams/graph`. This is Wave-B Round-2 of the 4.31 Teams sync.

New `src/chat_sdk/adapters/teams/graph/` subpackage (single-file `__init__.py`, mirroring the `slack/api` and Round-1 `teams/api` layout template). SDK-free: plain dicts + lazy `httpx`/stdlib, **no** `microsoft_teams` imports.

Reuses the Round-1 **api** primitive (now on main) via the allowed cross-subpath import: `resolve_teams_access_token`, `read_response_body`, `TeamsApiError` (and the lazy-httpx default fetch + response-protocol helpers).

### Ported (all 7 `graph/index.test.ts` `it` blocks + boundary)
- `call_teams_graph_api` — Microsoft Graph `.default` scope; absolute URL used as-is, relative path joined onto the base Graph URL
- `paginate_teams_graph` — follows `@odata.nextLink` **verbatim** (never re-encoded)
- `get_teams_channel` — channel metadata; `id` falls back to `channel_id`, `display_name` omitted when absent
- `list_teams_chat_messages` / `list_teams_channel_messages` / `list_teams_message_replies` — `$top` query-param join
- `get_teams_channel_message`, `to_graph_message`
- `extract_text_from_graph_message` — ordered regex HTML→text pass; entity-decode `&amp;` **last**

### SSRF divergence (Python-first, no upstream counterpart)
`call_teams_graph_api` gates an absolute `path_or_url` **and** every followed `@odata.nextLink` to the `graph.microsoft.com` host **before** resolving/attaching the Bearer token — raising `ValueError` for any other host. Upstream attaches the token to whatever URL the server hands back. A dedicated test asserts a hostile `@odata.nextLink` is rejected before the injected fetch is ever awaited (the token never leaves the process). Divergence-doc rows are consolidated in T7 (this lane does not touch `docs/UPSTREAM_SYNC.md` or `CHANGELOG.md`).

## Tests — `tests/test_teams_graph_primitive.py` (16, all green)
7 faithful index ports + boundary source-scan + no-eager-httpx import check + direct text-extraction coverage (incl. the `&amp;`-last ordering) + the nextLink-host SSRF rejection. Injectable **AsyncMock** fetch (not MagicMock). Mutation-checked: disabling the SSRF gate and reordering the entity decode both fail the relevant tests.

## Gauntlet (from worktree)
- `ruff check` — All checks passed
- `ruff format --check` — 270 files already formatted
- `audit_test_quality.py` — 0 hard failures
- `pyrefly check` — 0 errors
- `pytest tests/` — 4978 passed, 4 skipped

## Lane scope
Only two new files added; `teams/__init__.py` (lazy subpath registration deferred to T7), `adapter.py`, `CHANGELOG.md`, `docs/UPSTREAM_SYNC.md`, and other primitives are untouched.