### PR TITLE
feat(teams): modals primitive subpath (chat@4.31 8c71411)

### DIFF
--- a/src/chat_sdk/adapters/teams/modals.py
+++ b/src/chat_sdk/adapters/teams/modals.py
@@ -1,0 +1,437 @@
+"""Teams modals primitive — a lightweight, runtime-free subpath.
+
+Port of ``packages/adapter-teams/src/modals-primitives/{index,types}.ts`` (NEW
+in vercel/chat@4.31.0, commit ``8c71411``), exposed upstream as the
+``modals-primitives`` surface. Renders a structured ``Modal`` description into a
+Teams Adaptive Card, parses the values out of a Teams dialog-submit payload, and
+builds the ``task module`` response envelope for the close / errors / push /
+update variants.
+
+This is intentionally distinct from the SDK-bound modal handling in
+:mod:`chat_sdk.adapters.teams.adapter`. The helpers here are low-level
+primitives that operate purely on plain dicts and stdlib — importing this module
+never imports the ``microsoft_teams`` SDK, an HTTP client, or anything that
+performs network I/O.
+
+Reuse, not duplication:
+
+* Text escaping / emoji conversion delegates to
+  :func:`chat_sdk.adapters.teams.format.convert_teams_emoji_placeholders` (the
+  format primitive), exactly as upstream's ``index.ts`` imports
+  ``convertTeamsEmojiPlaceholders`` from ``../format``.
+* The ``fields`` modal child renders :class:`TeamsFieldElement` (``label`` /
+  ``value``) — the same field shape used by the cards primitive
+  (``TeamsFieldElement`` from ``../cards-primitives`` upstream). It is a plain
+  two-key ``TypedDict``; the modal-specific input element shapes
+  (``text_input`` / ``select`` / ``radio_select``) are defined here because
+  upstream defines them in ``modals-primitives/types.ts``, distinct from the
+  ``cards-primitives`` input request shapes in
+  :mod:`chat_sdk.adapters.teams.cards_input`.
+
+Wire-key fidelity (HAZARDS):
+
+* The reserved dialog-submit keys ``__callbackId`` / ``__contextId`` /
+  ``msteams`` are **literal** — they are *not* snake_cased. They round-trip the
+  Teams dialog submit and cross the SDK-state boundary, so they must match the
+  bytes Teams sends/expects verbatim. :func:`parse_teams_dialog_submit_values`
+  skips exactly those three reserved keys and nothing else.
+* The Adaptive Card content type is the literal
+  ``"application/vnd.microsoft.card.adaptive"``.
+* ``action == "close"`` (and a missing response) yields ``None`` — no card.
+* Only string-typed values pass the value filter (mirrors upstream's
+  ``typeof value === "string"``).
+
+Truthiness mirrors upstream intentionally: optional emit guards
+(``maxLength`` / ``placeholder`` / ``initialValue`` / ``initialOption`` /
+``contextId``) use truthiness so an empty string / ``maxLength: 0`` is omitted,
+byte-for-byte with the upstream ``...(x ? { ... } : {})`` spreads. The
+nullish-coalescing reads (``callbackId`` fallback, ``submitLabel`` default,
+``multiline`` / ``optional`` defaults) use ``is not None`` so an explicit empty
+string survives, matching upstream's ``??``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, NotRequired, TypedDict
+
+from chat_sdk.adapters.teams.format import convert_teams_emoji_placeholders
+
+__all__ = [
+    "ADAPTIVE_CARD_CONTENT_TYPE",
+    "TeamsDialogSubmitValues",
+    "TeamsFieldElement",
+    "TeamsFieldsModalElement",
+    "TeamsModalChild",
+    "TeamsModalElement",
+    "TeamsModalRadioSelectElement",
+    "TeamsModalResponse",
+    "TeamsModalSelectElement",
+    "TeamsModalSelectOption",
+    "TeamsModalTextElement",
+    "TeamsModalTextInputElement",
+    "TeamsTaskModuleResponse",
+    "modal_to_adaptive_card",
+    "parse_teams_dialog_submit_values",
+    "to_teams_task_module_response",
+]
+
+# The Adaptive Card content type Teams expects in a task-module ``continue``
+# envelope. Literal — must match Teams' wire format verbatim.
+ADAPTIVE_CARD_CONTENT_TYPE = "application/vnd.microsoft.card.adaptive"
+
+_ADAPTIVE_CARD_SCHEMA = "http://adaptivecards.io/schemas/adaptive-card.json"
+_ADAPTIVE_CARD_VERSION = "1.4"
+
+
+class TeamsFieldElement(TypedDict):
+    """One ``label`` / ``value`` row of a ``fields`` modal child.
+
+    Mirrors the ``TeamsFieldElement`` shared with the cards primitive
+    (upstream ``../cards-primitives``).
+    """
+
+    label: str
+    value: str
+
+
+class TeamsModalTextElement(TypedDict):
+    """A block of (optionally styled) text in a modal."""
+
+    content: str
+    type: Literal["text"]
+    style: NotRequired[Literal["bold", "muted", "plain"]]
+
+
+class TeamsFieldsModalElement(TypedDict):
+    """A ``FactSet`` of ``label`` / ``value`` rows."""
+
+    children: list[TeamsFieldElement]
+    type: Literal["fields"]
+
+
+class TeamsModalSelectOption(TypedDict):
+    """One selectable option in a ``select`` / ``radio_select`` element."""
+
+    label: str
+    value: str
+
+
+class TeamsModalTextInputElement(TypedDict):
+    """A single- or multi-line text input."""
+
+    id: str
+    label: str
+    type: Literal["text_input"]
+    initialValue: NotRequired[str]
+    maxLength: NotRequired[int]
+    multiline: NotRequired[bool]
+    optional: NotRequired[bool]
+    placeholder: NotRequired[str]
+
+
+class TeamsModalSelectElement(TypedDict):
+    """A dropdown (``compact``) choice set."""
+
+    id: str
+    label: str
+    options: list[TeamsModalSelectOption]
+    type: Literal["select"]
+    initialOption: NotRequired[str]
+    optional: NotRequired[bool]
+    placeholder: NotRequired[str]
+
+
+class TeamsModalRadioSelectElement(TypedDict):
+    """A radio (``expanded``) choice set — same fields as ``select``."""
+
+    id: str
+    label: str
+    options: list[TeamsModalSelectOption]
+    type: Literal["radio_select"]
+    initialOption: NotRequired[str]
+    optional: NotRequired[bool]
+    placeholder: NotRequired[str]
+
+
+TeamsModalChild = (
+    TeamsFieldsModalElement
+    | TeamsModalTextElement
+    | TeamsModalTextInputElement
+    | TeamsModalSelectElement
+    | TeamsModalRadioSelectElement
+)
+
+
+class TeamsModalElement(TypedDict):
+    """A complete modal description."""
+
+    callbackId: str
+    children: list[TeamsModalChild]
+    title: str
+    type: Literal["modal"]
+    submitLabel: NotRequired[str]
+
+
+class _TaskModuleValueCard(TypedDict):
+    content: Any
+    contentType: Literal["application/vnd.microsoft.card.adaptive"]
+
+
+class _TaskModuleValue(TypedDict):
+    card: _TaskModuleValueCard
+    title: str
+
+
+class _TaskModuleTask(TypedDict):
+    type: Literal["continue"]
+    value: _TaskModuleValue
+
+
+class TeamsTaskModuleResponse(TypedDict):
+    """The ``task module`` response envelope returned to Teams."""
+
+    task: _TaskModuleTask
+
+
+class _CloseResponse(TypedDict):
+    action: Literal["close"]
+
+
+class _ErrorsResponse(TypedDict):
+    action: Literal["errors"]
+    errors: dict[str, str]
+
+
+class _PushUpdateResponse(TypedDict):
+    action: Literal["push", "update"]
+    modal: TeamsModalElement
+
+
+TeamsModalResponse = _CloseResponse | _ErrorsResponse | _PushUpdateResponse
+
+
+class TeamsDialogSubmitValues(TypedDict):
+    """The parsed result of a Teams dialog submit."""
+
+    callbackId: str | None
+    contextId: str | None
+    values: dict[str, str]
+
+
+def modal_to_adaptive_card(
+    modal: TeamsModalElement,
+    options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Render a :class:`TeamsModalElement` into a Teams Adaptive Card dict.
+
+    Port of ``modalToAdaptiveCard``. ``options`` accepts ``callbackId`` and
+    ``contextId``. The submit action's ``data`` carries the reserved
+    ``__callbackId`` (and ``__contextId`` when present) literal keys so Teams
+    echoes them back on submit. ``callbackId`` falls back to the modal's own
+    ``callbackId`` (``??`` → ``is not None``); ``__contextId`` is only emitted
+    when truthy (mirrors upstream's ``...(options.contextId ? ... : {})``).
+    """
+    opts = options or {}
+    option_callback_id = opts.get("callbackId")
+    context_id = opts.get("contextId")
+
+    data: dict[str, Any] = {
+        "__callbackId": option_callback_id if option_callback_id is not None else modal["callbackId"],
+    }
+    if context_id:
+        data["__contextId"] = context_id
+
+    submit_label = modal.get("submitLabel")
+    body: list[Any] = []
+    for child in modal["children"]:
+        body.extend(_modal_child_to_adaptive_elements(child))
+
+    return {
+        "$schema": _ADAPTIVE_CARD_SCHEMA,
+        "actions": [
+            {
+                "data": data,
+                "style": "positive",
+                "title": submit_label if submit_label is not None else "Submit",
+                "type": "Action.Submit",
+            }
+        ],
+        "body": body,
+        "type": "AdaptiveCard",
+        "version": _ADAPTIVE_CARD_VERSION,
+    }
+
+
+def parse_teams_dialog_submit_values(
+    data: dict[str, Any] | None,
+) -> TeamsDialogSubmitValues:
+    """Extract the submitted values from a Teams dialog-submit payload.
+
+    Port of ``parseTeamsDialogSubmitValues``. The reserved keys
+    ``__callbackId`` / ``__contextId`` / ``msteams`` are skipped (exactly those
+    three, nothing else) and surfaced as ``callbackId`` / ``contextId`` only
+    when string-typed. Every other key is copied into ``values`` only when its
+    value is a string (mirrors upstream's ``typeof value === "string"``).
+    """
+    if not data:
+        return {"callbackId": None, "contextId": None, "values": {}}
+
+    values: dict[str, str] = {}
+    for key, value in data.items():
+        if key in ("__callbackId", "__contextId", "msteams"):
+            continue
+        if isinstance(value, str):
+            values[key] = value
+
+    raw_callback_id = data.get("__callbackId")
+    raw_context_id = data.get("__contextId")
+    return {
+        "callbackId": raw_callback_id if isinstance(raw_callback_id, str) else None,
+        "contextId": raw_context_id if isinstance(raw_context_id, str) else None,
+        "values": values,
+    }
+
+
+def to_teams_task_module_response(
+    response: TeamsModalResponse | None,
+    options: dict[str, Any] | None = None,
+) -> TeamsTaskModuleResponse | None:
+    """Build the task-module response for the close / errors / push / update variants.
+
+    Port of ``toTeamsTaskModuleResponse``. Returns ``None`` for a missing
+    response or ``action == "close"``. ``errors`` renders a validation card;
+    ``push`` / ``update`` render the modal as a ``continue`` card. ``options``
+    accepts ``contextId``, threaded into the rendered modal card.
+    """
+    opts = options or {}
+    if not response or response.get("action") == "close":
+        return None
+
+    if response.get("action") == "errors":
+        errors: dict[str, str] = response["errors"]  # type: ignore[typeddict-item]
+        error_blocks: list[Any] = [
+            {
+                "text": "Please fix the following errors:",
+                "type": "TextBlock",
+                "weight": "Bolder",
+                "wrap": True,
+            }
+        ]
+        for field, message in errors.items():
+            error_blocks.append(
+                {
+                    "color": "Attention",
+                    "text": f"**{field}**: {message}",
+                    "type": "TextBlock",
+                    "wrap": True,
+                }
+            )
+        return _continue_response(
+            "Validation Error",
+            {
+                "$schema": _ADAPTIVE_CARD_SCHEMA,
+                "body": error_blocks,
+                "type": "AdaptiveCard",
+                "version": _ADAPTIVE_CARD_VERSION,
+            },
+        )
+
+    modal: TeamsModalElement = response["modal"]  # type: ignore[typeddict-item]
+    return _continue_response(
+        modal["title"],
+        modal_to_adaptive_card(modal, {"contextId": opts.get("contextId")}),
+    )
+
+
+def _modal_child_to_adaptive_elements(child: TeamsModalChild) -> list[Any]:
+    child_type = child.get("type")
+    if child_type == "text":
+        return [_text_block(child)]  # type: ignore[arg-type]
+    if child_type == "fields":
+        return [_fields_block(child)]  # type: ignore[arg-type]
+    if child_type == "text_input":
+        return [_text_input(child)]  # type: ignore[arg-type]
+    if child_type == "select":
+        return [_choice_set(child, "compact")]  # type: ignore[arg-type]
+    if child_type == "radio_select":
+        return [_choice_set(child, "expanded")]  # type: ignore[arg-type]
+    return []
+
+
+def _text_block(element: TeamsModalTextElement) -> dict[str, Any]:
+    block: dict[str, Any] = {}
+    style = element.get("style")
+    if style == "bold":
+        block["weight"] = "Bolder"
+    if style == "muted":
+        block["isSubtle"] = True
+    block["text"] = convert_teams_emoji_placeholders(element["content"])
+    block["type"] = "TextBlock"
+    block["wrap"] = True
+    return block
+
+
+def _fields_block(element: TeamsFieldsModalElement) -> dict[str, Any]:
+    return {
+        "facts": [{"title": field["label"], "value": field["value"]} for field in element["children"]],
+        "type": "FactSet",
+    }
+
+
+def _text_input(input_element: TeamsModalTextInputElement) -> dict[str, Any]:
+    multiline = input_element.get("multiline")
+    optional = input_element.get("optional")
+    result: dict[str, Any] = {
+        "id": input_element["id"],
+        "isMultiline": multiline if multiline is not None else False,
+        "isRequired": not (optional if optional is not None else False),
+        "label": input_element["label"],
+    }
+    max_length = input_element.get("maxLength")
+    placeholder = input_element.get("placeholder")
+    initial_value = input_element.get("initialValue")
+    if max_length:
+        result["maxLength"] = max_length
+    if placeholder:
+        result["placeholder"] = placeholder
+    if initial_value:
+        result["value"] = initial_value
+    result["type"] = "Input.Text"
+    return result
+
+
+def _choice_set(
+    select: TeamsModalRadioSelectElement | TeamsModalSelectElement,
+    style: Literal["compact", "expanded"],
+) -> dict[str, Any]:
+    optional = select.get("optional")
+    result: dict[str, Any] = {
+        "choices": [{"title": option["label"], "value": option["value"]} for option in select["options"]],
+        "id": select["id"],
+        "isRequired": not (optional if optional is not None else False),
+        "label": select["label"],
+    }
+    placeholder = select.get("placeholder")
+    initial_option = select.get("initialOption")
+    if placeholder:
+        result["placeholder"] = placeholder
+    result["style"] = style
+    if initial_option:
+        result["value"] = initial_option
+    result["type"] = "Input.ChoiceSet"
+    return result
+
+
+def _continue_response(title: str, card: Any) -> TeamsTaskModuleResponse:
+    return {
+        "task": {
+            "type": "continue",
+            "value": {
+                "card": {
+                    "content": card,
+                    "contentType": ADAPTIVE_CARD_CONTENT_TYPE,
+                },
+                "title": title,
+            },
+        }
+    }

--- a/tests/test_teams_modals_primitive.py
+++ b/tests/test_teams_modals_primitive.py
@@ -1,0 +1,269 @@
+"""Tests for the Teams modals primitive (``chat_sdk.adapters.teams.modals``).
+
+Port of upstream ``packages/adapter-teams/src/modals-primitives/index.test.ts``
+and ``modals-primitives/boundary.test.ts`` (NEW in vercel/chat@4.31.0, commit
+``8c71411``). One Python test per upstream ``it(...)`` plus the boundary
+source-scan / fresh-interpreter no-eager-import test.
+
+Upstream uses ``toMatchObject`` (partial, deep) and ``toEqual`` (exact). Where
+upstream is partial we assert the load-bearing subset explicitly; where it is
+exact (``toEqual`` / ``toBeUndefined``) we assert equality / ``None`` so the
+test fails on any divergence.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from chat_sdk.adapters.teams.modals import (
+    TeamsModalElement,
+    TeamsModalResponse,
+    modal_to_adaptive_card,
+    parse_teams_dialog_submit_values,
+    to_teams_task_module_response,
+)
+
+# Shared fixture mirroring the upstream module-level ``modal`` const.
+MODAL: TeamsModalElement = {
+    "callbackId": "deploy-modal",
+    "children": [
+        {"content": "Deploy?", "style": "bold", "type": "text"},
+        {
+            "id": "reason",
+            "label": "Reason",
+            "placeholder": "Why?",
+            "type": "text_input",
+        },
+    ],
+    "title": "Deploy",
+    "type": "modal",
+}
+
+
+class TestTeamsModalPrimitives:
+    """Mirror of upstream ``describe("Teams modal primitives")``."""
+
+    def test_converts_modal_objects_to_adaptive_cards(self) -> None:
+        """it("converts modal objects to Adaptive Cards")."""
+        card = modal_to_adaptive_card(MODAL, {"contextId": "ctx"})
+
+        assert card["type"] == "AdaptiveCard"
+        assert card["actions"] == [
+            {
+                "data": {"__callbackId": "deploy-modal", "__contextId": "ctx"},
+                "style": "positive",
+                "title": "Submit",
+                "type": "Action.Submit",
+            }
+        ]
+        # First body element: bold text → Bolder weight.
+        assert card["body"][0] == {
+            "text": "Deploy?",
+            "type": "TextBlock",
+            "weight": "Bolder",
+            "wrap": True,
+        }
+        # Second body element: the text input.
+        assert card["body"][1]["id"] == "reason"
+        assert card["body"][1]["label"] == "Reason"
+        assert card["body"][1]["type"] == "Input.Text"
+
+    def test_parses_dialog_submit_values(self) -> None:
+        """it("parses dialog submit values")."""
+        assert parse_teams_dialog_submit_values(
+            {
+                "__callbackId": "cb",
+                "__contextId": "ctx",
+                "msteams": {},
+                "reason": "approved",
+            }
+        ) == {
+            "callbackId": "cb",
+            "contextId": "ctx",
+            "values": {"reason": "approved"},
+        }
+
+    def test_creates_task_module_responses(self) -> None:
+        """it("creates task module responses")."""
+        update: TeamsModalResponse = {"action": "update", "modal": MODAL}
+        response = to_teams_task_module_response(update, {"contextId": "ctx"})
+        assert response is not None
+        assert response["task"]["type"] == "continue"
+        assert response["task"]["value"]["card"]["contentType"] == "application/vnd.microsoft.card.adaptive"
+        assert response["task"]["value"]["title"] == "Deploy"
+
+        close: TeamsModalResponse = {"action": "close"}
+        assert to_teams_task_module_response(close) is None
+
+    def test_renders_validation_errors_as_a_continue_response(self) -> None:
+        """it("renders validation errors as a continue response")."""
+        errors: TeamsModalResponse = {"action": "errors", "errors": {"reason": "Required"}}
+        response = to_teams_task_module_response(errors)
+        assert response is not None
+        assert response["task"]["value"]["title"] == "Validation Error"
+        body = response["task"]["value"]["card"]["content"]["body"]
+        assert any(block.get("text") == "**reason**: Required" for block in body)
+
+    def test_converts_every_modal_child_type_with_options_and_styles(self) -> None:
+        """it("converts every modal child type with options and styles")."""
+        card = modal_to_adaptive_card(
+            {
+                "callbackId": "cb",
+                "children": [
+                    {"content": "Muted", "style": "muted", "type": "text"},
+                    {
+                        "children": [{"label": "Owner", "value": "Ada"}],
+                        "type": "fields",
+                    },
+                    {
+                        "id": "summary",
+                        "initialValue": "init",
+                        "label": "Summary",
+                        "maxLength": 200,
+                        "multiline": True,
+                        "placeholder": "Describe",
+                        "type": "text_input",
+                    },
+                    {
+                        "id": "env",
+                        "initialOption": "prod",
+                        "label": "Env",
+                        "optional": True,
+                        "options": [{"label": "Prod", "value": "prod"}],
+                        "placeholder": "Pick",
+                        "type": "select",
+                    },
+                    {
+                        "id": "strategy",
+                        "label": "Strategy",
+                        "options": [{"label": "BG", "value": "bg"}],
+                        "type": "radio_select",
+                    },
+                ],
+                "submitLabel": "Go",
+                "title": "All",
+                "type": "modal",
+            },
+            {},
+        )
+
+        # Submit action uses the modal callbackId (no option override / contextId).
+        assert card["actions"][0]["data"] == {"__callbackId": "cb"}
+        assert card["actions"][0]["title"] == "Go"
+
+        body = card["body"]
+        by_id = {block.get("id"): block for block in body if "id" in block}
+
+        # Muted text → isSubtle (no weight key).
+        muted = next(b for b in body if b.get("text") == "Muted")
+        assert muted["isSubtle"] is True
+        assert "weight" not in muted
+
+        # FactSet from the fields child.
+        fact_set = next(b for b in body if b.get("type") == "FactSet")
+        assert fact_set["facts"] == [{"title": "Owner", "value": "Ada"}]
+
+        # Multiline, required text input with maxLength / placeholder / value.
+        summary = by_id["summary"]
+        assert summary["isMultiline"] is True
+        assert summary["isRequired"] is True
+        assert summary["maxLength"] == 200
+        assert summary["placeholder"] == "Describe"
+        assert summary["type"] == "Input.Text"
+        assert summary["value"] == "init"
+
+        # Optional compact ChoiceSet → not required, initialOption → value.
+        env = by_id["env"]
+        assert env["isRequired"] is False
+        assert env["placeholder"] == "Pick"
+        assert env["style"] == "compact"
+        assert env["type"] == "Input.ChoiceSet"
+        assert env["value"] == "prod"
+
+        # Radio → expanded ChoiceSet, required (no optional flag).
+        strategy = by_id["strategy"]
+        assert strategy["isRequired"] is True
+        assert strategy["style"] == "expanded"
+        assert strategy["type"] == "Input.ChoiceSet"
+
+    def test_prefers_the_callback_id_option_over_the_modal_callback_id(self) -> None:
+        """it("prefers the callbackId option over the modal callbackId")."""
+        card = modal_to_adaptive_card(MODAL, {"callbackId": "override"})
+        assert card["actions"][0]["data"] == {"__callbackId": "override"}
+
+    def test_returns_empty_submit_values_when_data_is_missing(self) -> None:
+        """it("returns empty submit values when data is missing")."""
+        assert parse_teams_dialog_submit_values(None) == {
+            "callbackId": None,
+            "contextId": None,
+            "values": {},
+        }
+
+    def test_ignores_non_string_submit_values(self) -> None:
+        """it("ignores non-string submit values")."""
+        assert parse_teams_dialog_submit_values({"count": 5, "note": "ok"}) == {
+            "callbackId": None,
+            "contextId": None,
+            "values": {"note": "ok"},
+        }
+
+    def test_creates_continue_responses_for_push_actions(self) -> None:
+        """it("creates continue responses for push actions")."""
+        push: TeamsModalResponse = {"action": "push", "modal": MODAL}
+        response = to_teams_task_module_response(push)
+        assert response is not None
+        assert response["task"]["type"] == "continue"
+        assert response["task"]["value"]["title"] == "Deploy"
+
+    def test_returns_undefined_when_there_is_no_response(self) -> None:
+        """it("returns undefined when there is no response")."""
+        assert to_teams_task_module_response(None) is None
+
+
+class TestModalsImportBoundary:
+    """Port of upstream ``modals-primitives/boundary.test.ts``.
+
+    Upstream's boundary test is a static source-scan: it reads every non-test
+    ``.ts`` in the directory and asserts the source never imports the full
+    adapter (``"chat"``), the shared runtime, or ``@microsoft/teams.apps``. We
+    port that source-scan over the modals primitive's ``.py`` file, and add a
+    fresh-interpreter assertion that importing the subpath never eagerly loads
+    the ``microsoft_teams`` SDK or an HTTP client (httpx / aiohttp). The
+    cross-primitive import from ``chat_sdk.adapters.teams.format`` is expected
+    and allowed (it mirrors upstream's ``import ... from "../format"``); only
+    the high-level adapter / SDK / HTTP imports are forbidden.
+    """
+
+    def test_modals_source_does_not_import_the_adapter_sdk_or_runtime(self) -> None:
+        from chat_sdk.adapters.teams import modals as modals_mod
+
+        source = Path(modals_mod.__file__).read_text(encoding="utf-8")
+
+        # No Teams SDK import in any form.
+        assert "import microsoft_teams" not in source
+        assert "from microsoft_teams" not in source
+        # No high-level adapter / shared-runtime / cards-runtime imports.
+        assert "from chat_sdk.adapters.teams.adapter" not in source
+        assert "import chat_sdk.adapters.teams.adapter" not in source
+        assert "from chat_sdk.adapters.teams.bridge" not in source
+        # No eager HTTP-client import.
+        assert "\nimport httpx" not in source
+        assert "\nimport aiohttp" not in source
+
+    def test_importing_modals_does_not_eagerly_import_sdk_or_http_client(self) -> None:
+        code = (
+            "import sys\n"
+            "import chat_sdk.adapters.teams.modals\n"
+            "forbidden = ['microsoft_teams', 'httpx', 'aiohttp']\n"
+            "loaded = [name for name in forbidden if name in sys.modules]\n"
+            "assert not loaded, f'modals subpath eagerly imported: {loaded}'\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Ports the net-new Teams **modals** primitive (Wave B group T4) faithfully from upstream `chat@4.31.0` `packages/adapter-teams/src/modals-primitives/{index,types}.ts` (NEW in 4.31, commit `8c71411` — the directory does not exist in 4.30).

New module `chat_sdk.adapters.teams.modals` — an SDK-free, runtime-free subpath, intentionally distinct from the SDK-bound modal handling in `adapter.py`:

- **`modal_to_adaptive_card`** — render a `Modal` into a Teams Adaptive Card. Reuses the **format** primitive (`convert_teams_emoji_placeholders`) for text and the cards-primitive `TeamsFieldElement` (label/value) for the `fields` child; the modal-specific input shapes (`text_input` / `select` / `radio_select`) match upstream `modals-primitives/types.ts`.
- **`parse_teams_dialog_submit_values`** — extract submitted values, skipping exactly the three reserved wire keys.
- **`to_teams_task_module_response`** — build the close / errors / push / update task-module envelope.

## Hazards handled

- Reserved wire keys `__callbackId` / `__contextId` / `msteams` stay **literal** (dunder-prefixed, NOT snake_cased) — they round-trip the Teams dialog submit and cross the SDK-state boundary. `parse_teams_dialog_submit_values` skips exactly those three and nothing else.
- `action == "close"` (and a missing response) → `None`, no card.
- Content type is the literal `application/vnd.microsoft.card.adaptive`.
- Only string-typed values pass the value filter (mirrors upstream `typeof value === "string"`; empty strings are kept, non-strings dropped).
- Optional emit guards use **truthiness** (so empty string / `maxLength: 0` is omitted, byte-for-byte with upstream `...(x ? {…} : {})`); nullish-coalescing reads use `is not None` per the port rules.

## Emit parity

The produced Adaptive Card / task-module JSON was diffed against the upstream object literals key-for-key (every child type, the validation-error card, and the reserved-key parse). A mutation check (breaking the content-type literal) fails a test; restoring passes all 12.

## Tests

`tests/test_teams_modals_primitive.py` — 10 `it` ports (1:1 with upstream `index.test.ts`) + boundary: a **source-scan** (no `microsoft_teams` / adapter / bridge / eager httpx-aiohttp imports) AND a **fresh-interpreter** no-eager-import assertion. 12 passed.

## Gauntlet

- `ruff check` / `ruff format --check`: pass
- `audit_test_quality.py`: 0 hard failures (no new duplicate-warning groups)
- `pyrefly check`: 0 errors
- `pytest tests/`: 5006 passed, 4 skipped

## Lane scoping

Only `src/chat_sdk/adapters/teams/modals.py` + its test. No touch to `teams/__init__.py` (lazy registration deferred to T7), `adapter.py`, other primitives, `CHANGELOG.md`, or `docs/UPSTREAM_SYNC.md`.

## Divergences (for T7)

1. **No lazy registration** — `teams/__init__.py` is untouched; the subpath is importable directly but not yet exposed via package-level lazy registration (deferred to T7 per lane scoping).
2. **`docs/UPSTREAM_SYNC.md` not updated** — no new SSRF/divergence note is warranted (this primitive performs no network I/O and adds no URL handling), but the new subpath should be recorded in the sync doc / known-non-parity list as part of T7.
3. **Boundary test split** — upstream's single `boundary.test.ts` `it` is ported as two Python tests (static source-scan + fresh-interpreter no-eager-import), matching the existing graph/cards primitive test convention in this repo.
4. **Typed-dict fixtures** — Python tests annotate the shared `MODAL` fixture and response payloads as `TeamsModalElement` / `TeamsModalResponse` so pyrefly accepts the literals (upstream uses TS `as const`); no behavioral difference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Teams modal support enabling creation and conversion of modal dialogs to Adaptive Cards format
  * Added parsing functionality for Teams dialog submission values including callback and context data
  * Added task module response generation for modal actions

* **Tests**
  * Added comprehensive test coverage for modal conversion, dialog parsing, and response handling
  * Added import boundary tests to ensure module isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->