### PR TITLE
feat(telegram): rich-message wire types for Bot API 10.1 (chat@4.31 4662309 — TG1/4)

### DIFF
--- a/src/chat_sdk/adapters/telegram/types.py
+++ b/src/chat_sdk/adapters/telegram/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from chat_sdk.logger import Logger
 
@@ -160,6 +160,106 @@ class TelegramPhotoSize(TypedDict, total=False):
     width: int  # required
 
 
+class TelegramAnimation(TypedDict, total=False):
+    """Telegram animation (GIF or H.264/MPEG-4 AVC video without sound).
+
+    Extends TelegramFile. See https://core.telegram.org/bots/api#animation
+    """
+
+    file_id: str  # required
+    file_path: str
+    file_size: int
+    file_unique_id: str
+    duration: int  # required
+    file_name: str
+    height: int  # required
+    mime_type: str
+    thumbnail: TelegramPhotoSize
+    width: int  # required
+
+
+class TelegramAudio(TypedDict, total=False):
+    """Telegram audio file to be treated as music.
+
+    Extends TelegramFile. See https://core.telegram.org/bots/api#audio
+    """
+
+    file_id: str  # required
+    file_path: str
+    file_size: int
+    file_unique_id: str
+    duration: int  # required
+    file_name: str
+    mime_type: str
+    performer: str
+    thumbnail: TelegramPhotoSize
+    title: str
+
+
+class TelegramLocation(TypedDict, total=False):
+    """Telegram location on a map.
+
+    See https://core.telegram.org/bots/api#location
+    """
+
+    heading: int
+    horizontal_accuracy: float
+    latitude: float  # required
+    live_period: int
+    longitude: float  # required
+    proximity_alert_radius: int
+
+
+class TelegramVideoQuality(TypedDict, total=False):
+    """Available quality of a Telegram video.
+
+    Extends TelegramFile. See https://core.telegram.org/bots/api#video
+    """
+
+    file_id: str  # required
+    file_path: str
+    file_size: int
+    file_unique_id: str
+    codec: str  # required
+    height: int  # required
+    width: int  # required
+
+
+class TelegramVideo(TypedDict, total=False):
+    """Telegram video file.
+
+    Extends TelegramFile. See https://core.telegram.org/bots/api#video
+    """
+
+    file_id: str  # required
+    file_path: str
+    file_size: int
+    file_unique_id: str
+    cover: list[TelegramPhotoSize]
+    duration: int  # required
+    file_name: str
+    height: int  # required
+    mime_type: str
+    qualities: list[TelegramVideoQuality]
+    start_timestamp: int
+    thumbnail: TelegramPhotoSize
+    width: int  # required
+
+
+class TelegramVoice(TypedDict, total=False):
+    """Telegram voice note.
+
+    Extends TelegramFile. See https://core.telegram.org/bots/api#voice
+    """
+
+    file_id: str  # required
+    file_path: str
+    file_size: int
+    file_unique_id: str
+    duration: int  # required
+    mime_type: str
+
+
 class TelegramAudioFile(TypedDict, total=False):
     """Telegram audio file with extra metadata."""
 
@@ -195,19 +295,6 @@ class TelegramStickerFile(TypedDict, total=False):
     emoji: str
 
 
-class TelegramVideoFile(TypedDict, total=False):
-    """Telegram video file with extra metadata."""
-
-    file_id: str  # required
-    file_path: str
-    file_size: int
-    file_unique_id: str
-    width: int
-    height: int
-    mime_type: str
-    file_name: str
-
-
 class TelegramVideoNoteFile(TypedDict, total=False):
     """Telegram video note (round video message) with extra metadata."""
 
@@ -228,6 +315,374 @@ class TelegramVoiceFile(TypedDict, total=False):
     file_unique_id: str
     duration: int
     mime_type: str
+
+
+# =============================================================================
+# Rich message wire types (Bot API 10.1)
+#
+# Rich messages are recursive: a TelegramRichText may nest further
+# TelegramRichText, and a TelegramRichBlock may nest further blocks. The
+# recursion is expressed with quoted forward references in TypeAlias string
+# RHS values (e.g. "... | list[TelegramRichText] | ...") so the aliases never
+# evaluate ``|`` against a not-yet-defined name at runtime while pyrefly still
+# resolves them statically.
+#
+# Wire keys are snake_case: the Telegram Bot API is natively snake_case, so
+# there is no camelCase serialization boundary here (unlike most adapters).
+# =============================================================================
+
+
+class TelegramRichTextStyled(TypedDict):
+    """Styled rich-text span (bold, italic, code, etc)."""
+
+    type: Literal[
+        "bold",
+        "italic",
+        "underline",
+        "strikethrough",
+        "spoiler",
+        "subscript",
+        "superscript",
+        "marked",
+        "code",
+    ]
+    text: TelegramRichText
+
+
+class TelegramRichTextDateTime(TypedDict):
+    """Rich-text date/time span."""
+
+    type: Literal["date_time"]
+    text: TelegramRichText
+    unix_time: int
+    date_time_format: str
+
+
+class TelegramRichTextTextMention(TypedDict):
+    """Rich-text mention of a user without a username."""
+
+    type: Literal["text_mention"]
+    text: TelegramRichText
+    user: TelegramUser
+
+
+class TelegramRichTextCustomEmoji(TypedDict):
+    """Rich-text custom emoji span."""
+
+    type: Literal["custom_emoji"]
+    alternative_text: str
+    custom_emoji_id: str
+
+
+class TelegramRichTextMath(TypedDict):
+    """Rich-text inline mathematical expression."""
+
+    type: Literal["mathematical_expression"]
+    expression: str
+
+
+class TelegramRichTextUrl(TypedDict):
+    """Rich-text URL span."""
+
+    type: Literal["url"]
+    text: TelegramRichText
+    url: str
+
+
+class TelegramRichTextEmailAddress(TypedDict):
+    """Rich-text email address span."""
+
+    type: Literal["email_address"]
+    email_address: str
+    text: TelegramRichText
+
+
+class TelegramRichTextPhoneNumber(TypedDict):
+    """Rich-text phone number span."""
+
+    type: Literal["phone_number"]
+    phone_number: str
+    text: TelegramRichText
+
+
+class TelegramRichTextBankCardNumber(TypedDict):
+    """Rich-text bank card number span."""
+
+    type: Literal["bank_card_number"]
+    bank_card_number: str
+    text: TelegramRichText
+
+
+class TelegramRichTextMention(TypedDict):
+    """Rich-text @username mention span."""
+
+    type: Literal["mention"]
+    text: TelegramRichText
+    username: str
+
+
+class TelegramRichTextHashtag(TypedDict):
+    """Rich-text hashtag span."""
+
+    type: Literal["hashtag"]
+    hashtag: str
+    text: TelegramRichText
+
+
+class TelegramRichTextCashtag(TypedDict):
+    """Rich-text cashtag span."""
+
+    type: Literal["cashtag"]
+    cashtag: str
+    text: TelegramRichText
+
+
+class TelegramRichTextBotCommand(TypedDict):
+    """Rich-text bot command span."""
+
+    type: Literal["bot_command"]
+    bot_command: str
+    text: TelegramRichText
+
+
+class TelegramRichTextAnchor(TypedDict):
+    """Rich-text anchor target span."""
+
+    type: Literal["anchor"]
+    name: str
+
+
+class TelegramRichTextAnchorLink(TypedDict):
+    """Rich-text anchor link span."""
+
+    type: Literal["anchor_link"]
+    anchor_name: str
+    text: TelegramRichText
+
+
+class TelegramRichTextReference(TypedDict):
+    """Rich-text reference target span."""
+
+    type: Literal["reference"]
+    name: str
+    text: TelegramRichText
+
+
+class TelegramRichTextReferenceLink(TypedDict):
+    """Rich-text reference link span."""
+
+    type: Literal["reference_link"]
+    reference_name: str
+    text: TelegramRichText
+
+
+# Recursive rich-text union. The RHS is a quoted forward reference so the
+# self-reference (``list[TelegramRichText]`` and the ``text`` fields above)
+# resolves statically without a runtime NameError.
+# See https://core.telegram.org/bots/api#richtext
+TelegramRichText: TypeAlias = "str | list[TelegramRichText] | TelegramRichTextStyled | TelegramRichTextDateTime | TelegramRichTextTextMention | TelegramRichTextCustomEmoji | TelegramRichTextMath | TelegramRichTextUrl | TelegramRichTextEmailAddress | TelegramRichTextPhoneNumber | TelegramRichTextBankCardNumber | TelegramRichTextMention | TelegramRichTextHashtag | TelegramRichTextCashtag | TelegramRichTextBotCommand | TelegramRichTextAnchor | TelegramRichTextAnchorLink | TelegramRichTextReference | TelegramRichTextReferenceLink"  # noqa: E501
+
+
+class TelegramRichCaption(TypedDict, total=False):
+    """Caption attached to a rich message block.
+
+    See https://core.telegram.org/bots/api#richblockcaption
+    """
+
+    credit: TelegramRichText
+    text: TelegramRichText  # required
+
+
+class TelegramRichCell(TypedDict, total=False):
+    """Cell in a rich message table.
+
+    See https://core.telegram.org/bots/api#richblocktablecell
+    """
+
+    align: Literal["left", "center", "right"]  # required
+    colspan: int
+    is_header: Literal[True]
+    rowspan: int
+    text: TelegramRichText
+    valign: Literal["top", "middle", "bottom"]  # required
+
+
+class TelegramRichItem(TypedDict, total=False):
+    """Item in a rich message list.
+
+    See https://core.telegram.org/bots/api#richblocklistitem
+    """
+
+    blocks: list[TelegramRichBlock]  # required
+    has_checkbox: Literal[True]
+    is_checked: Literal[True]
+    label: str  # required
+    type: Literal["a", "A", "i", "I", "1"]
+    value: int
+
+
+class TelegramRichBlockText(TypedDict):
+    """Rich block: paragraph, footer or thinking text."""
+
+    type: Literal["paragraph", "footer", "thinking"]
+    text: TelegramRichText
+
+
+class TelegramRichBlockHeading(TypedDict):
+    """Rich block: heading."""
+
+    type: Literal["heading"]
+    size: int
+    text: TelegramRichText
+
+
+class TelegramRichBlockPre(TypedDict, total=False):
+    """Rich block: preformatted / code block."""
+
+    type: Literal["pre"]  # required
+    language: str
+    text: TelegramRichText  # required
+
+
+class TelegramRichBlockDivider(TypedDict):
+    """Rich block: horizontal divider."""
+
+    type: Literal["divider"]
+
+
+class TelegramRichBlockMath(TypedDict):
+    """Rich block: block-level mathematical expression."""
+
+    type: Literal["mathematical_expression"]
+    expression: str
+
+
+class TelegramRichBlockAnchor(TypedDict):
+    """Rich block: anchor target."""
+
+    type: Literal["anchor"]
+    name: str
+
+
+class TelegramRichBlockList(TypedDict):
+    """Rich block: list of items."""
+
+    type: Literal["list"]
+    items: list[TelegramRichItem]
+
+
+class TelegramRichBlockBlockquote(TypedDict, total=False):
+    """Rich block: blockquote."""
+
+    type: Literal["blockquote"]  # required
+    blocks: list[TelegramRichBlock]  # required
+    credit: TelegramRichText
+
+
+class TelegramRichBlockPullquote(TypedDict, total=False):
+    """Rich block: pullquote."""
+
+    type: Literal["pullquote"]  # required
+    credit: TelegramRichText
+    text: TelegramRichText  # required
+
+
+class TelegramRichBlockCollage(TypedDict, total=False):
+    """Rich block: collage or slideshow of nested blocks."""
+
+    type: Literal["collage", "slideshow"]  # required
+    blocks: list[TelegramRichBlock]  # required
+    caption: TelegramRichCaption
+
+
+class TelegramRichBlockTable(TypedDict, total=False):
+    """Rich block: table."""
+
+    type: Literal["table"]  # required
+    caption: TelegramRichText
+    cells: list[list[TelegramRichCell]]  # required
+    is_bordered: Literal[True]
+    is_striped: Literal[True]
+
+
+class TelegramRichBlockDetails(TypedDict, total=False):
+    """Rich block: collapsible details/summary."""
+
+    type: Literal["details"]  # required
+    blocks: list[TelegramRichBlock]  # required
+    is_open: Literal[True]
+    summary: TelegramRichText  # required
+
+
+class TelegramRichBlockMap(TypedDict, total=False):
+    """Rich block: map."""
+
+    type: Literal["map"]  # required
+    caption: TelegramRichCaption
+    height: int  # required
+    location: TelegramLocation  # required
+    width: int  # required
+    zoom: int  # required
+
+
+class TelegramRichBlockAnimation(TypedDict, total=False):
+    """Rich block: animation."""
+
+    type: Literal["animation"]  # required
+    animation: TelegramAnimation  # required
+    caption: TelegramRichCaption
+    has_spoiler: Literal[True]
+
+
+class TelegramRichBlockAudio(TypedDict, total=False):
+    """Rich block: audio."""
+
+    type: Literal["audio"]  # required
+    audio: TelegramAudio  # required
+    caption: TelegramRichCaption
+
+
+class TelegramRichBlockPhoto(TypedDict, total=False):
+    """Rich block: photo."""
+
+    type: Literal["photo"]  # required
+    caption: TelegramRichCaption
+    has_spoiler: Literal[True]
+    photo: list[TelegramPhotoSize]  # required
+
+
+class TelegramRichBlockVideo(TypedDict, total=False):
+    """Rich block: video."""
+
+    type: Literal["video"]  # required
+    caption: TelegramRichCaption
+    has_spoiler: Literal[True]
+    video: TelegramVideo  # required
+
+
+class TelegramRichBlockVoiceNote(TypedDict, total=False):
+    """Rich block: voice note."""
+
+    type: Literal["voice_note"]  # required
+    caption: TelegramRichCaption
+    voice_note: TelegramVoice  # required
+
+
+# Recursive rich-block union. As with TelegramRichText, the RHS is a quoted
+# forward reference so nested ``list[TelegramRichBlock]`` self-references
+# resolve statically without a runtime NameError.
+# See https://core.telegram.org/bots/api#richblock
+TelegramRichBlock: TypeAlias = "TelegramRichBlockText | TelegramRichBlockHeading | TelegramRichBlockPre | TelegramRichBlockDivider | TelegramRichBlockMath | TelegramRichBlockAnchor | TelegramRichBlockList | TelegramRichBlockBlockquote | TelegramRichBlockPullquote | TelegramRichBlockCollage | TelegramRichBlockTable | TelegramRichBlockDetails | TelegramRichBlockMap | TelegramRichBlockAnimation | TelegramRichBlockAudio | TelegramRichBlockPhoto | TelegramRichBlockVideo | TelegramRichBlockVoiceNote"  # noqa: E501
+
+
+class TelegramRichMessage(TypedDict, total=False):
+    """Rich formatted message received from Telegram.
+
+    See https://core.telegram.org/bots/api#richmessage
+    """
+
+    blocks: list[TelegramRichBlock]  # required
+    is_rtl: bool
 
 
 class TelegramMessage(TypedDict, total=False):
@@ -256,10 +711,11 @@ class TelegramMessage(TypedDict, total=False):
     message_id: int  # required
     message_thread_id: int
     photo: list[TelegramPhotoSize]
+    rich_message: TelegramRichMessage
     sender_chat: TelegramChat
     sticker: TelegramStickerFile
     text: str
-    video: TelegramVideoFile
+    video: TelegramVideo
     video_note: TelegramVideoNoteFile
     voice: TelegramVoiceFile
 

--- a/tests/test_telegram_types.py
+++ b/tests/test_telegram_types.py
@@ -12,6 +12,13 @@ that:
 
 pyrefly is the primary gate for these types (recursive unions); the assertions
 below also catch a typo'd wire key at runtime.
+
+Typing note: ``TelegramRichText`` / ``TelegramRichBlock`` are recursive *unions*
+that pyrefly cannot narrow from a bare dict literal. Each fixture is therefore
+annotated with its concrete variant TypedDict (e.g. ``TelegramRichBlockText``),
+and recursion into a nested union member is bound to a typed intermediate local
+of the concrete variant so subscripting type-checks. The runtime ``type`` /
+``text`` assertions still exercise the recursive shapes end to end.
 """
 
 from __future__ import annotations
@@ -22,8 +29,21 @@ from chat_sdk.adapters.telegram.types import (
     TelegramLocation,
     TelegramMessage,
     TelegramRichBlock,
+    TelegramRichBlockAnimation,
+    TelegramRichBlockAudio,
+    TelegramRichBlockBlockquote,
+    TelegramRichBlockHeading,
+    TelegramRichBlockList,
+    TelegramRichBlockMap,
+    TelegramRichBlockTable,
+    TelegramRichBlockText,
+    TelegramRichBlockVideo,
+    TelegramRichBlockVoiceNote,
+    TelegramRichItem,
     TelegramRichMessage,
     TelegramRichText,
+    TelegramRichTextStyled,
+    TelegramRichTextUrl,
     TelegramVideo,
     TelegramVideoQuality,
     TelegramVoice,
@@ -43,12 +63,13 @@ def test_recursive_aliases_resolve_at_runtime() -> None:
 def test_rich_text_nested_spans() -> None:
     """A TelegramRichText may be a plain string, a list, or a styled span dict."""
     plain: TelegramRichText = "hello"
-    nested: TelegramRichText = [
-        "Read ",
-        {"type": "url", "text": "the guide", "url": "https://example.com"},
-        " and ",
-        {"type": "bold", "text": "continue"},
-    ]
+    url_span: TelegramRichTextUrl = {
+        "type": "url",
+        "text": "the guide",
+        "url": "https://example.com",
+    }
+    bold_span: TelegramRichTextStyled = {"type": "bold", "text": "continue"}
+    nested: list[TelegramRichText] = ["Read ", url_span, " and ", bold_span]
     assert plain == "hello"
     assert isinstance(nested, list)
     assert nested[1] == {
@@ -57,79 +78,81 @@ def test_rich_text_nested_spans() -> None:
         "url": "https://example.com",
     }
     # Recursion: a span's text may itself be a list of spans.
-    deep: TelegramRichText = {
-        "type": "italic",
-        "text": [{"type": "bold", "text": "x"}],
-    }
-    assert deep["text"][0]["type"] == "bold"
+    inner_bold: TelegramRichTextStyled = {"type": "bold", "text": "x"}
+    deep: TelegramRichTextStyled = {"type": "italic", "text": [inner_bold]}
+    deep_text = deep["text"]
+    assert isinstance(deep_text, list)
+    first: TelegramRichTextStyled = deep_text[0]  # type: ignore[assignment]
+    assert first["type"] == "bold"
 
 
 def test_rich_message_with_heading_paragraph_and_table() -> None:
     """Mirror of the upstream rich.test.ts structured-blocks fixture."""
-    message: TelegramRichMessage = {
-        "blocks": [
-            {"type": "heading", "size": 2, "text": "Summary"},
-            {
-                "type": "paragraph",
-                "text": [
-                    "Read ",
-                    {"type": "url", "text": "the guide", "url": "https://example.com"},
-                    " and ",
-                    {"type": "bold", "text": "continue"},
-                ],
-            },
-            {
-                "type": "table",
-                "cells": [
-                    [
-                        {
-                            "align": "left",
-                            "is_header": True,
-                            "text": "Name",
-                            "valign": "top",
-                        },
-                        {
-                            "align": "right",
-                            "is_header": True,
-                            "text": "Status",
-                            "valign": "top",
-                        },
-                    ],
-                    [
-                        {"align": "left", "text": "Build", "valign": "top"},
-                        {"align": "right", "text": "Ready", "valign": "top"},
-                    ],
-                ],
-            },
+    heading: TelegramRichBlockHeading = {
+        "type": "heading",
+        "size": 2,
+        "text": "Summary",
+    }
+    url_span: TelegramRichTextUrl = {
+        "type": "url",
+        "text": "the guide",
+        "url": "https://example.com",
+    }
+    bold_span: TelegramRichTextStyled = {"type": "bold", "text": "continue"}
+    paragraph: TelegramRichBlockText = {
+        "type": "paragraph",
+        "text": ["Read ", url_span, " and ", bold_span],
+    }
+    table: TelegramRichBlockTable = {
+        "type": "table",
+        "cells": [
+            [
+                {
+                    "align": "left",
+                    "is_header": True,
+                    "text": "Name",
+                    "valign": "top",
+                },
+                {
+                    "align": "right",
+                    "is_header": True,
+                    "text": "Status",
+                    "valign": "top",
+                },
+            ],
+            [
+                {"align": "left", "text": "Build", "valign": "top"},
+                {"align": "right", "text": "Ready", "valign": "top"},
+            ],
         ],
     }
+    message: TelegramRichMessage = {"blocks": [heading, paragraph, table]}
     blocks = message["blocks"]
-    assert blocks[0]["type"] == "heading"
-    assert blocks[0]["size"] == 2
+    head_block: TelegramRichBlockHeading = blocks[0]  # type: ignore[assignment]
+    assert head_block["type"] == "heading"
+    assert head_block["size"] == 2
     # Recursion into a table cell's text.
-    assert blocks[2]["cells"][0][0]["is_header"] is True
-    assert blocks[2]["cells"][1][1]["text"] == "Ready"
+    table_block: TelegramRichBlockTable = blocks[2]  # type: ignore[assignment]
+    assert table_block["cells"][0][0]["is_header"] is True
+    assert table_block["cells"][1][1]["text"] == "Ready"
 
 
 def test_rich_block_nested_blocks_recursion() -> None:
     """Blockquote / list blocks nest further TelegramRichBlock values."""
-    block: TelegramRichBlock = {
+    quoted: TelegramRichBlockText = {"type": "paragraph", "text": "quoted"}
+    item_para: TelegramRichBlockText = {"type": "paragraph", "text": "a"}
+    list_item: TelegramRichItem = {"label": "first", "blocks": [item_para]}
+    list_block: TelegramRichBlockList = {"type": "list", "items": [list_item]}
+    block: TelegramRichBlockBlockquote = {
         "type": "blockquote",
-        "blocks": [
-            {"type": "paragraph", "text": "quoted"},
-            {
-                "type": "list",
-                "items": [
-                    {"label": "first", "blocks": [{"type": "paragraph", "text": "a"}]},
-                ],
-            },
-        ],
+        "blocks": [quoted, list_block],
         "credit": "someone",
     }
-    inner = block["blocks"][1]
+    inner: TelegramRichBlockList = block["blocks"][1]  # type: ignore[assignment]
     assert inner["type"] == "list"
     # Recursion: list item blocks are themselves TelegramRichBlock values.
-    assert inner["items"][0]["blocks"][0]["text"] == "a"
+    nested_para: TelegramRichBlockText = inner["items"][0]["blocks"][0]  # type: ignore[assignment]
+    assert nested_para["text"] == "a"
 
 
 def test_rich_block_media_blocks() -> None:
@@ -156,23 +179,36 @@ def test_rich_block_media_blocks() -> None:
         "qualities": [quality],
         "start_timestamp": 5,
     }
-    message: TelegramRichMessage = {
-        "blocks": [
-            {"type": "animation", "animation": animation, "has_spoiler": True},
-            {"type": "audio", "audio": audio},
-            {"type": "video", "video": video, "has_spoiler": True},
-            {"type": "voice_note", "voice_note": voice},
-        ],
+    anim_block: TelegramRichBlockAnimation = {
+        "type": "animation",
+        "animation": animation,
+        "has_spoiler": True,
     }
-    assert message["blocks"][0]["animation"]["width"] == 640
-    assert message["blocks"][2]["video"]["qualities"][0]["codec"] == "h264"
-    assert message["blocks"][3]["voice_note"]["mime_type"] == "audio/ogg"
+    audio_block: TelegramRichBlockAudio = {"type": "audio", "audio": audio}
+    video_block: TelegramRichBlockVideo = {
+        "type": "video",
+        "video": video,
+        "has_spoiler": True,
+    }
+    voice_block: TelegramRichBlockVoiceNote = {
+        "type": "voice_note",
+        "voice_note": voice,
+    }
+    message: TelegramRichMessage = {
+        "blocks": [anim_block, audio_block, video_block, voice_block],
+    }
+    block0: TelegramRichBlockAnimation = message["blocks"][0]  # type: ignore[assignment]
+    block2: TelegramRichBlockVideo = message["blocks"][2]  # type: ignore[assignment]
+    block3: TelegramRichBlockVoiceNote = message["blocks"][3]  # type: ignore[assignment]
+    assert block0["animation"]["width"] == 640
+    assert block2["video"]["qualities"][0]["codec"] == "h264"
+    assert block3["voice_note"]["mime_type"] == "audio/ogg"
 
 
 def test_rich_block_map_uses_location() -> None:
     """The map block embeds a TelegramLocation with float lat/long."""
     location: TelegramLocation = {"latitude": 40.0, "longitude": -73.0}
-    block: TelegramRichBlock = {
+    block: TelegramRichBlockMap = {
         "type": "map",
         "height": 200,
         "width": 300,
@@ -185,16 +221,16 @@ def test_rich_block_map_uses_location() -> None:
 
 def test_telegram_message_carries_rich_message() -> None:
     """TelegramMessage gains an optional rich_message payload in 4.31."""
+    paragraph: TelegramRichBlockText = {"type": "paragraph", "text": "hi"}
+    rich: TelegramRichMessage = {"blocks": [paragraph], "is_rtl": False}
     message: TelegramMessage = {
         "chat": {"id": 1, "type": "private"},
         "date": 0,
         "message_id": 7,
-        "rich_message": {
-            "blocks": [{"type": "paragraph", "text": "hi"}],
-            "is_rtl": False,
-        },
+        "rich_message": rich,
     }
-    assert message["rich_message"]["blocks"][0]["text"] == "hi"
+    first_block: TelegramRichBlockText = message["rich_message"]["blocks"][0]  # type: ignore[assignment]
+    assert first_block["text"] == "hi"
     assert message["rich_message"]["is_rtl"] is False
 
 

--- a/tests/test_telegram_types.py
+++ b/tests/test_telegram_types.py
@@ -1,0 +1,215 @@
+"""Structural / typing tests for Telegram rich-message wire types (Bot API 10.1).
+
+These types are TypedDict wire shapes mirroring upstream
+``adapter-telegram/src/types.ts`` (chat@4.31.0, commit 4662309). The runtime
+logic that consumes them (``rich.py``) lands in a later PR; here we only verify
+that:
+
+- the recursive ``TelegramRichText`` / ``TelegramRichBlock`` aliases resolve at
+  runtime (the quoted forward-ref TypeAlias strings do not raise), and
+- representative nested ``rich_message`` payloads — taken from the upstream
+  ``rich.test.ts`` fixtures — construct with the expected snake_case keys.
+
+pyrefly is the primary gate for these types (recursive unions); the assertions
+below also catch a typo'd wire key at runtime.
+"""
+
+from __future__ import annotations
+
+from chat_sdk.adapters.telegram.types import (
+    TelegramAnimation,
+    TelegramAudio,
+    TelegramLocation,
+    TelegramMessage,
+    TelegramRichBlock,
+    TelegramRichMessage,
+    TelegramRichText,
+    TelegramVideo,
+    TelegramVideoQuality,
+    TelegramVoice,
+)
+
+
+def test_recursive_aliases_resolve_at_runtime() -> None:
+    """The quoted forward-ref TypeAlias strings must not raise on import/use."""
+    # Module-level aliases evaluate to the unioned string at runtime (they are
+    # quoted forward refs), but they must exist and be referenceable.
+    assert isinstance(TelegramRichText, str)
+    assert "TelegramRichText" in TelegramRichText
+    assert isinstance(TelegramRichBlock, str)
+    assert "TelegramRichBlock" in TelegramRichBlock
+
+
+def test_rich_text_nested_spans() -> None:
+    """A TelegramRichText may be a plain string, a list, or a styled span dict."""
+    plain: TelegramRichText = "hello"
+    nested: TelegramRichText = [
+        "Read ",
+        {"type": "url", "text": "the guide", "url": "https://example.com"},
+        " and ",
+        {"type": "bold", "text": "continue"},
+    ]
+    assert plain == "hello"
+    assert isinstance(nested, list)
+    assert nested[1] == {
+        "type": "url",
+        "text": "the guide",
+        "url": "https://example.com",
+    }
+    # Recursion: a span's text may itself be a list of spans.
+    deep: TelegramRichText = {
+        "type": "italic",
+        "text": [{"type": "bold", "text": "x"}],
+    }
+    assert deep["text"][0]["type"] == "bold"
+
+
+def test_rich_message_with_heading_paragraph_and_table() -> None:
+    """Mirror of the upstream rich.test.ts structured-blocks fixture."""
+    message: TelegramRichMessage = {
+        "blocks": [
+            {"type": "heading", "size": 2, "text": "Summary"},
+            {
+                "type": "paragraph",
+                "text": [
+                    "Read ",
+                    {"type": "url", "text": "the guide", "url": "https://example.com"},
+                    " and ",
+                    {"type": "bold", "text": "continue"},
+                ],
+            },
+            {
+                "type": "table",
+                "cells": [
+                    [
+                        {
+                            "align": "left",
+                            "is_header": True,
+                            "text": "Name",
+                            "valign": "top",
+                        },
+                        {
+                            "align": "right",
+                            "is_header": True,
+                            "text": "Status",
+                            "valign": "top",
+                        },
+                    ],
+                    [
+                        {"align": "left", "text": "Build", "valign": "top"},
+                        {"align": "right", "text": "Ready", "valign": "top"},
+                    ],
+                ],
+            },
+        ],
+    }
+    blocks = message["blocks"]
+    assert blocks[0]["type"] == "heading"
+    assert blocks[0]["size"] == 2
+    # Recursion into a table cell's text.
+    assert blocks[2]["cells"][0][0]["is_header"] is True
+    assert blocks[2]["cells"][1][1]["text"] == "Ready"
+
+
+def test_rich_block_nested_blocks_recursion() -> None:
+    """Blockquote / list blocks nest further TelegramRichBlock values."""
+    block: TelegramRichBlock = {
+        "type": "blockquote",
+        "blocks": [
+            {"type": "paragraph", "text": "quoted"},
+            {
+                "type": "list",
+                "items": [
+                    {"label": "first", "blocks": [{"type": "paragraph", "text": "a"}]},
+                ],
+            },
+        ],
+        "credit": "someone",
+    }
+    inner = block["blocks"][1]
+    assert inner["type"] == "list"
+    # Recursion: list item blocks are themselves TelegramRichBlock values.
+    assert inner["items"][0]["blocks"][0]["text"] == "a"
+
+
+def test_rich_block_media_blocks() -> None:
+    """Media blocks carry the new named media wire types with snake_case keys."""
+    animation: TelegramAnimation = {
+        "file_id": "anim1",
+        "duration": 3,
+        "height": 480,
+        "width": 640,
+    }
+    audio: TelegramAudio = {"file_id": "aud1", "duration": 12, "title": "Song"}
+    voice: TelegramVoice = {"file_id": "v1", "duration": 5, "mime_type": "audio/ogg"}
+    quality: TelegramVideoQuality = {
+        "file_id": "q1",
+        "codec": "h264",
+        "height": 720,
+        "width": 1280,
+    }
+    video: TelegramVideo = {
+        "file_id": "vid1",
+        "duration": 30,
+        "height": 1080,
+        "width": 1920,
+        "qualities": [quality],
+        "start_timestamp": 5,
+    }
+    message: TelegramRichMessage = {
+        "blocks": [
+            {"type": "animation", "animation": animation, "has_spoiler": True},
+            {"type": "audio", "audio": audio},
+            {"type": "video", "video": video, "has_spoiler": True},
+            {"type": "voice_note", "voice_note": voice},
+        ],
+    }
+    assert message["blocks"][0]["animation"]["width"] == 640
+    assert message["blocks"][2]["video"]["qualities"][0]["codec"] == "h264"
+    assert message["blocks"][3]["voice_note"]["mime_type"] == "audio/ogg"
+
+
+def test_rich_block_map_uses_location() -> None:
+    """The map block embeds a TelegramLocation with float lat/long."""
+    location: TelegramLocation = {"latitude": 40.0, "longitude": -73.0}
+    block: TelegramRichBlock = {
+        "type": "map",
+        "height": 200,
+        "width": 300,
+        "zoom": 12,
+        "location": location,
+    }
+    assert block["location"]["latitude"] == 40.0
+    assert block["zoom"] == 12
+
+
+def test_telegram_message_carries_rich_message() -> None:
+    """TelegramMessage gains an optional rich_message payload in 4.31."""
+    message: TelegramMessage = {
+        "chat": {"id": 1, "type": "private"},
+        "date": 0,
+        "message_id": 7,
+        "rich_message": {
+            "blocks": [{"type": "paragraph", "text": "hi"}],
+            "is_rtl": False,
+        },
+    }
+    assert message["rich_message"]["blocks"][0]["text"] == "hi"
+    assert message["rich_message"]["is_rtl"] is False
+
+
+def test_telegram_message_video_is_widened() -> None:
+    """The message ``video`` field is the widened TelegramVideo in 4.31."""
+    message: TelegramMessage = {
+        "chat": {"id": 1, "type": "private"},
+        "date": 0,
+        "message_id": 8,
+        "video": {
+            "file_id": "vid",
+            "duration": 10,
+            "height": 720,
+            "width": 1280,
+            "cover": [{"file_id": "c", "height": 720, "width": 1280}],
+        },
+    }
+    assert message["video"]["cover"][0]["file_id"] == "c"


### PR DESCRIPTION
First PR of the 4.31 Wave C Telegram rich-message port (TG1/4). **Types only** — no runtime logic (that's TG2 `rich.py` / TG3 / TG4).

Faithful port of the wire types added upstream in **chat@4.31.0** (commit `4662309`, "native rich message formatting + streaming for Bot API 10.1"), diffed `adapter-telegram/src/types.ts` 4.30 → 4.31. Edits are confined to `src/chat_sdk/adapters/telegram/types.py` (+ a new types test).

## What was added (vs upstream `types.ts`)

**New named media interfaces** (each extends `TelegramFile`, except `TelegramLocation`):
- `TelegramAnimation` — `duration`, `file_name?`, `height`, `mime_type?`, `thumbnail?`, `width`
- `TelegramAudio` — `duration`, `file_name?`, `mime_type?`, `performer?`, `thumbnail?`, `title?`
- `TelegramLocation` — `heading?`, `horizontal_accuracy?`, `latitude`, `live_period?`, `longitude`, `proximity_alert_radius?`
- `TelegramVideoQuality` — `codec`, `height`, `width`
- `TelegramVideo` (widened) — `cover?`, `duration`, `file_name?`, `height`, `mime_type?`, `qualities?`, `start_timestamp?`, `thumbnail?`, `width`
- `TelegramVoice` — `duration`, `mime_type?`

**Recursive rich-text structures:**
- `TelegramRichText` — union of `str`, `list[TelegramRichText]`, and 19 styled/entity span variants (each a discriminated TypedDict on `type`)
- `TelegramRichCaption`, `TelegramRichCell`, `TelegramRichItem`
- `TelegramRichBlock` — union of 18 block variants (paragraph/heading/pre/divider/list/blockquote/table/map/animation/audio/photo/video/voice_note/…)
- `TelegramRichMessage` — `blocks`, `is_rtl?`

**`TelegramMessage` changes:** adds optional `rich_message: TelegramRichMessage`; widens `video` from the old inline shape to the named `TelegramVideo` (the now-redundant `TelegramVideoFile` is dropped — it had no external references; the adapter only reads `file_id`/`width`/`height`/`file_name`/`mime_type`/`file_size`, all present on `TelegramVideo`).

## How the recursion is expressed

The two recursive unions (`TelegramRichText`, `TelegramRichBlock`) are declared as **quoted forward-ref `TypeAlias` strings** — a single contiguous string literal RHS:

```python
TelegramRichText: TypeAlias = "str | list[TelegramRichText] | TelegramRichTextStyled | ... "
```

The RHS is never evaluated as a `|` expression at runtime, so the self-reference (`list[TelegramRichText]`, nested `text:` fields, `list[TelegramRichBlock]` in blocks/items/cells) raises no `NameError`, while pyrefly still resolves it statically. (An implicitly-concatenated multi-string RHS was tried first but pyrefly reads that as a `Literal[...]` rather than a forward ref — hence the single-string form + `# noqa: E501`.)

## Hazards handled

- **Wire keys stay snake_case** — the Telegram Bot API is natively snake_case, so there is **no camelCase serialization boundary** here (unlike most adapters). Keys match Bot API field names exactly.
- Optional fields via `total=False` + `# required` markers (existing file style); `true`-only flags as `Literal[True]`.
- `latitude`/`longitude`/`horizontal_accuracy` typed `float` (Bot API Floats); integer fields stay `int`.
- No invented fields — every field copied 1:1 from upstream.

## Gauntlet

- pyrefly: **0 errors** (the key gate for the recursive unions)
- ruff check + ruff format --check: pass
- `audit_test_quality.py`: 0 hard failures (new test in no duplicate group)
- pytest: 8 new tests pass; full Telegram suite (313) green; full repo suite **5026 passed, 4 skipped**

## For later PRs (TG2/TG3/TG4)

- `rich.py` (TG2) consumes `TelegramRichMessage` / `TelegramRichBlock` / `TelegramRichText` to render markdown/plaintext — upstream `rich.test.ts` fixtures already validate against these shapes.
- The discriminant is the `type` field on every block/span variant; media blocks reference `TelegramAnimation`/`TelegramAudio`/`TelegramVideo`/`TelegramVoice`/`TelegramPhotoSize` and `TelegramLocation` (map block).
- The adapter message-parsing path (TG3) can now read `message["rich_message"]` and the widened `message["video"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)