### PR TITLE
chore(release): 0.4.31.1 — Slack #138 + #95 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.31.1
+
+Python-only fixes on top of `4.31.0` (`UPSTREAM_PARITY` unchanged at `4.31.0`). Two Slack adapter bug fixes, both divergences ahead of upstream (which shares the same gaps), documented in `docs/UPSTREAM_SYNC.md`.
+
+- **Slack: empty-DM `thread_ts` fetch routing** (#138). DM roots encode an empty `thread_ts` (`slack:Dxxx:`); the fetch paths (`fetch_messages`/`fetch_message`) called `conversations.replies(ts='')`, which returns no replies and loses the DM root context. They now route an empty `thread_ts` to the existing channel-history path (`conversations.history`) instead — covering DM messages and the #137 DM block-action consumer uniformly. The non-empty (real thread) path is byte-identical.
+- **Slack: `chat.startStream` `team_not_found` on Enterprise Grid** (#95). `chat.startStream` requires an explicit `team_id` for Grid orgs, but `stream()` started the stream without one (while non-streaming `chat.postMessage` worked). The streaming call now threads `team_id` (from the already-plumbed `recipient_team_id`, the per-workspace `T…` id) through to `chat.startStream`. Verified end-to-end against `slack_sdk` that the value reaches the `chat.startStream` API call; `append`/`stop` correctly do not need it. (Live Enterprise-Grid server-side acceptance is pending verification against a real Grid tenant.)
+- **Docs:** marked Linear `"agent-sessions"` mode **experimental** in `LinearAdapterConfig` — its emit/fetch GraphQL is schema-hardened but unverified against a live Linear agent-session tenant (#151).
+
 ## 0.4.31
 
 Synced to upstream `vercel/chat@4.31.0`. The mapped-core **test** files (`packages/chat/src/*.test.ts`) are byte-identical between the `chat@4.30.0` and `chat@4.31.0` tags, so the fidelity re-pin to `chat@4.31.0` is string-only (732/732 mapped-core tests still pass, 0 missing); the core **source** delta is the `LinkButton` stable-id field (below). The headline is the **Linear agent-sessions** mode, plus the **Teams SDK-free primitive subpaths**, the **Slack 4.31** changes, **Telegram rich messages**, and a Python-only opt-in **`ThinkingChunk`** stream type. Sets `UPSTREAM_PARITY = "4.31.0"`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Our version embeds the upstream Vercel Chat version: `0.{upstream_major}.{upstre
 - `0.4.29` = synced to upstream `4.29.0` (upstream never tagged 4.27/4.28 as `chat@*`)
 - `0.4.30` = synced to upstream `4.30.0`
 - `0.4.31` = synced to upstream `4.31.0`
+- `0.4.31.1` = Python-only fixes on top of `4.31.0` (Slack #138/#95)
 - `UPSTREAM_PARITY` constant in `__init__.py` = programmatic access
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Multi-platform async chat SDK for Python. Port of [Vercel Chat](https://github.com/vercel/chat).
 
-> **Status: 0.4.31 — synced to [Vercel Chat 4.31.0](https://github.com/vercel/chat)** (`UPSTREAM_PARITY = "4.31.0"`). See [CHANGELOG.md](CHANGELOG.md).
+> **Status: 0.4.31.1 — synced to [Vercel Chat 4.31.0](https://github.com/vercel/chat)** (`UPSTREAM_PARITY = "4.31.0"`). See [CHANGELOG.md](CHANGELOG.md).
 
 ## Why chat-sdk?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-sdk"
-version = "0.4.31"
+version = "0.4.31.1"
 description = "Multi-platform async chat SDK for Python — port of Vercel Chat"
 keywords = [
     "chat",

--- a/src/chat_sdk/adapters/linear/types.py
+++ b/src/chat_sdk/adapters/linear/types.py
@@ -46,6 +46,12 @@ class LinearAdapterBaseConfig:
     # handling. Defaults to "comments". Use "agent-sessions" for app-actor
     # installs. Faithful port of upstream ``config.mode ?? "comments"``
     # (types.ts:67, index.ts:236).
+    #
+    # NOTE: ``"agent-sessions"`` mode is **experimental** in this port. The
+    # agent-session emit/fetch paths are raw GraphQL that was schema-hardened
+    # against Linear's published schema but has **not** been exercised against
+    # a live Linear agent-session tenant (tracked in issue #151). The default
+    # ``"comments"`` mode is unaffected.
     mode: LinearAdapterMode | None = None
     # Bot display name for @-mention detection.
     # Defaults to LINEAR_BOT_USERNAME env var or "linear-bot".


### PR DESCRIPTION
Cuts **0.4.31.1** — a Python-only patch on `4.31.0` (`UPSTREAM_PARITY` unchanged at `4.31.0`) bundling the two merged Slack adapter fixes.

## Included (already merged to main)
- **#138** (PR #175) — empty-DM `thread_ts` fetch routes to `conversations.history` instead of `conversations.replies(ts='')`; non-empty path byte-identical.
- **#95** (PR #176) — `chat.startStream` threads `team_id` (= `recipient_team_id`) for Enterprise Grid; verified end-to-end against `slack_sdk` that it reaches the API call.

## This PR
- `pyproject` version `0.4.31` → `0.4.31.1`; README status; CLAUDE.md version-mapping
- CHANGELOG 0.4.31.1 entry
- Docs: marked Linear `"agent-sessions"` mode **experimental** in `LinearAdapterConfig` (schema-hardened but unverified vs a live tenant, #151)

## Validation (local)
ruff + format clean · audit 0 hard failures · pyrefly 0 · fidelity 732/732 `--strict` @ chat@4.31.0 · full suite green.

Next: deploy to customer-demo (git-ref) and live-verify #138 (DM fetch) + #95 (Grid stream) before the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)